### PR TITLE
Fixed hh reductions / extensions / optimization / cleanuppery

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -138,11 +138,6 @@ void Game::reset(){
     }
 #endif
 
-    // Clear eval cache
-#if USINGEVALCACHE
-    memset(evalHash, 0, evalHashSize * sizeof(evalHashEntry));
-#endif
-
 }
 
 /**
@@ -237,9 +232,6 @@ bool Game::makeMove(Move move){
     repetitionTable[pos.totalPly] = pos.hashKey;
 #endif
     bool k = pos.makeMove(move);
-#if ENABLEPREFETCHING && ENABLETTSCORING
-    prefetch(&evalHash[hashEntryFor(pos.hashKey)]);
-#endif
     return k;
 }
 
@@ -257,8 +249,7 @@ bool Game::isRepetition() {
     for (int idx = 4; idx < dist; idx += 2){
         if (repetitionTable[startPoint - idx] == hashKey) {
             if (idx < ply) return true;
-            counter++;
-            if (counter >= 2) return true;
+            if (++counter >= 2) return true;
         }
     }
     return false;

--- a/src/constants.h
+++ b/src/constants.h
@@ -100,9 +100,6 @@ enum Squares {
 #define EVASIONSINQUIESCENCE            true // If true the search function will search for evasions in quiescence search. Quiescence search must be enabled for this to work.
 #define DODELTAPRUNING                  true // If true the delta pruning is used. Quiescence search must be enabled for this to work.
 
-// EVALUATION TECHNIQUES
-#define USINGEVALCACHE                  false // If true the evaluation cache is used. The evaluation cache is automatically implemented in the evaluation function if this is true.
-
 // DEBUGGING SYMBOL DEFINITIONS
 #define DEBUG                           false // If true the debugging is used. The debugging is automatically implemented in the code if this is true.
 #define ASSERTS                         true // If true the asserts are used. The asserts are automatically implemented in the code if this is true.

--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -317,14 +317,6 @@ static inline void mobility(const BitBoard (&bb)[12], const BitBoard (&occ)[3], 
 
 Score pestoEval2(Position* pos) {
 
-#if USINGEVALCACHE
-    Score cachedEval = getCachedEval(pos->hashKey);
-    if (cachedEval != noScore) {
-        int fCs = std::min(60, std::max(0, pos->fiftyMove - 12));
-        return cachedEval * (100 - fCs) / 100;
-    }
-#endif
-
     auto const& bb = pos->bitboards;
     Score mg[2] = { 0,0 }, eg[2] = { 0,0 };
     Score whiteMaterial, blackMaterial;
@@ -1186,11 +1178,7 @@ Score pestoEval2(Position* pos) {
     Score res = (Score)(((int)mgScore * (int)mgPhase + (int)egScore * (int)egPhase) / 24);
     //if (res >= egValues[Q] + egValues[N]) res += (KNOWNWIN/2) - ((res) * abs(KNOWNWIN/2))/mateScore;
 	//if (res <= egValues[Q] + egValues[N]) res += (-KNOWNWIN / 2) - ((res) * abs(-KNOWNWIN / 2)) / mateScore;
-    
-#if USINGEVALCACHE
-    // Cache res before scaling
-    cacheEval(pos->hashKey, res);
-#endif
+
     return res * (100 - fC) / 100;
 
 }

--- a/src/tt.cpp
+++ b/src/tt.cpp
@@ -23,12 +23,9 @@ ttEntry::ttEntry() {
 
 // Transposition table and evaluation hash table
 std::vector<ttEntry> tt;
-evalHashEntry* evalHash;
 
 void initTT(){
     resizeTT(hashSize);
-    if(evalHash != nullptr) delete[] evalHash;
-    evalHash = new evalHashEntry[evalHashSize];
 }
 
 ttEntry* probeTT(HashKey key) {
@@ -76,18 +73,6 @@ void writeTT(HashKey key, Score score, Score staticEval, Depth depth, U8 flags, 
         entry->flags = flags;
     }
     entry->bestMove = move;
-}
-
-Score getCachedEval(HashKey h){
-    evalHashEntry &e = evalHash[h % (evalHashSize)];
-    if (e.hashKey == h) return e.score;
-    return noScore;
-}
-
-void cacheEval(HashKey h, Score s){
-    evalHashEntry* e = &evalHash[h % (evalHashSize)];
-    e->hashKey = h;
-    e->score = s;
 }
 
 U16 hashfull() {

--- a/src/tt.h
+++ b/src/tt.h
@@ -7,7 +7,6 @@
 constexpr U64 ttEntryCount = 1048576;                      // 2^20
 constexpr U64 ttBucketSize = 4;                            // 2^2
 constexpr U64 ttBucketCount = ttEntryCount / ttBucketSize; // 2^18
-constexpr U64 evalHashSize = 1048576;                      // 2^20
 
 // The enum of hashFlags
 enum HashFlag
@@ -21,16 +20,6 @@ enum HashFlag
     hashSINGULAR = 32,
     hashEVALONLY = 64,
     hashPVMove = 128
-};
-
-struct evalHashEntry {
-    evalHashEntry(HashKey h, Score score);
-    evalHashEntry() {
-        hashKey = 0;
-        score = 0;
-    }
-    HashKey hashKey = 0;
-    Score score = 0;
 };
 
 #ifdef _MSC_VER
@@ -93,7 +82,6 @@ struct ttBucket {
 
 // Transposition table and evaluation hash table
 extern std::vector<ttEntry> tt;
-extern evalHashEntry* evalHash;
 
 inline U64 hashEntryFor(HashKey key) {
     return static_cast<U64>(
@@ -136,18 +124,5 @@ ttEntry *probeTT(HashKey key);
  * @param isPv The isPv flag.
  */
 void writeTT(HashKey key, Score score, Score staticEval, Depth depth, U8 flags, Move move, Ply ply, bool isPv);
-
-/**
- * The getCachedEval function looks up for evaluation of position and returns it if found, else noScore
- * @param hash the hash to look for
- */
-Score getCachedEval(HashKey h);
-
-/**
- * The cacheEval function caches an evaluation. Uses an always replace scheme
- * @param hash the hash to look for
- * @param score the score to store
- */
-void cacheEval(HashKey h, Score s);
 
 U16 hashfull();


### PR DESCRIPTION
```
Finished tournament.
Results of TEST vs DEV:
Elo: 24.90 +/- 10.53, nElo: 33.86 +/- 14.27
LOS: 100.00 %, DrawRatio: 39.16 %, PairsRatio: 1.39
Games: 2278, Wins: 786, Losses: 623, Draws: 869, Points: 1220.5 (53.58 %)
Ptnml(0-2): [68, 222, 446, 285, 118]
LLR: 2.96 (-2.94, 2.94) [0.00, 5.00]
```

`bench: 3951396`

Fixed history reductions, optimized away some ifs, removed ancient styled Delta pruning in qsearch, removed unused variables and code