### PR TITLE
Improved makefile structure and cached intermediate files to speed up compilations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src/chessdata.zip
 src/visualizer.ipynb
 src/chessdata.zip
 src/visualizer.ipynb
+src/obj

--- a/src/build.mk
+++ b/src/build.mk
@@ -1,0 +1,49 @@
+TARGET ?= Release
+OBJ_DIR = obj/$(TARGET)
+
+CPP_FILES := $(wildcard *.cpp)
+OBJ_FILES = $(addprefix $(OBJ_DIR)/, $(CPP_FILES:.cpp=.o))
+
+CXX ?= g++
+CXXFLAGS := -Wall -Wextra -Wpedantic -std=c++17 -Wno-implicit-fallthrough
+NATIVE := -march=native -mpopcnt
+EXE ?= Perseus
+
+ifeq ($(TARGET), Release)
+	CXXFLAGS += -funroll-loops -O3 -flto -fno-exceptions -DNDEBUG -lm
+else ifeq ($(TARGET), Debug)
+	CXXFLAGS += -g -O0 -fsanitize=address -fno-omit-frame-pointer -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
+else
+	$(error "Unknown target: $(TARGET)")
+endif
+
+.PHONY: all build dirs link clean
+
+all: build
+
+build: dirs $(OBJ_FILES) link 
+
+dirs:
+ifeq ($(OS),Windows_NT)
+	@if not exist $(subst /,\,$(OBJ_DIR)) mkdir $(subst /,\,$(OBJ_DIR))
+else
+	@mkdir -p $(OBJ_DIR)
+endif 
+
+$(OBJ_DIR)/%.o: %.cpp
+	@echo "Compiling $<"
+	$(CXX) $(CXXFLAGS) $(NATIVE) -c $< -o $@
+
+link:
+	@echo "Linking"
+	$(CXX) $(CXXFLAGS) $(NATIVE) $(OBJ_FILES) -o $(EXE)
+
+clean:
+	@echo "Cleaning"
+ifeq ($(OS),Windows_NT)
+	@if exist $(subst /,\,$(OBJ_DIR)) rmdir /s /q $(subst /,\,$(OBJ_DIR))
+	@if exist $(EXE).exe del $(EXE).exe
+else
+	@rm -rf $(OBJ_DIR)
+	@rm -f $(EXE)
+endif

--- a/src/build.mk
+++ b/src/build.mk
@@ -32,11 +32,11 @@ endif
 
 $(OBJ_DIR)/%.o: %.cpp
 	@echo "Compiling $<"
-	$(CXX) $(CXXFLAGS) $(NATIVE) -c $< -o $@
+	@$(CXX) $(CXXFLAGS) $(NATIVE) -c $< -o $@
 
 link:
 	@echo "Linking"
-	$(CXX) $(CXXFLAGS) $(NATIVE) $(OBJ_FILES) -o $(EXE)
+	@$(CXX) $(CXXFLAGS) $(NATIVE) $(OBJ_FILES) -o $(EXE)
 
 clean:
 	@echo "Cleaning"

--- a/src/makefile
+++ b/src/makefile
@@ -1,43 +1,12 @@
-# This makefile is used to build the program.
-# We will configure two targets: one for debug and one for release.
-# The debug target will be used to build the program with debug symbols.
-# The release target will be used to build the program without debug symbols.
-
-THIS := $(realpath $(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
-ROOT := $(realpath $(THIS)/..)
-CXX := g++
-TARGET:= Perseus
-CXXFLAGS := -Wall -std=c++17
-NATIVE := -march=native -mpopcnt
-
-NAME := $(TARGET)
-
-# Detect OS
-ifeq ($(OS),Windows_NT)
-	OS := Windows_NT
-	SUFFIX := .exe
-else
-	OS := $(shell uname -s)
-	SUFFIX :=
-endif
-
-# I am too lazy to include apple support
-SOURCES := $(wildcard *.cpp)
-EXECUTABLE := $(NAME)$(SUFFIX)
-
 .PHONY: all debug release
 
 all: release
 
-# Debug target
-debug: CXXFLAGS += -g -O0 -fsanitize=address -fno-omit-frame-pointer -D_GLIBCXX_DEBUG -D_GLIBCXX_DEBUG_PEDANTIC
-debug: $(EXECUTABLE)
+release:
+	@$(MAKE) -f build.mk TARGET=Release
 
-# Release target
-release: CXXFLAGS += -funroll-loops -O3 -flto -fno-exceptions -DNDEBUG -lm
-release: $(EXECUTABLE)
+debug:
+	@$(MAKE) -sf build.mk TARGET=Debug
 
-
-# Build the program
-$(EXECUTABLE): $(SOURCES)
-	$(CXX) $(CXXFLAGS) $(NATIVE) $(SOURCES) -o $@
+clean:
+	@$(MAKE) -sf build.mk clean

--- a/src/makefile
+++ b/src/makefile
@@ -3,7 +3,7 @@
 all: release
 
 release:
-	@$(MAKE) -f build.mk TARGET=Release
+	@$(MAKE) -sf build.mk TARGET=Release
 
 debug:
 	@$(MAKE) -sf build.mk TARGET=Debug


### PR DESCRIPTION
As per title, the general file structure of the Makefile has been updated to follow a cleaner standard. This structure caches the object files and allows the system to understand which file needs to be regenerated, speeding up compilation times.
It also adds the possibility to specify the compiler with `make CXX=<>` and the name of the executable with `make EXE=<>` as per OpenBench standard.

---
Nodes: 9297401 (unchanged)