### PR TITLE
bench 5194389

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -179,7 +179,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
     if (inCheck)
     {
         ss->staticEval = eval = rawEval = noScore;
-        // improving = false;
+        improving = false;
         goto skipPruning;
     }
     
@@ -196,6 +196,8 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
     }
     else if (excludedMove){
         eval = ss->staticEval; // We already have the eval from the main search in the current ss entry
+        improving = false;
+        goto skipPruning;
     }
     else {
         rawEval = evaluate();


### PR DESCRIPTION
Elo   | 7.74 +- 5.10 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7768 W: 2247 L: 2074 D: 3447
Penta | [180, 873, 1619, 1018, 194]
https://perseusopenbench.pythonanywhere.com/test/132/