### PR TITLE
bench 5194389

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -739,8 +739,8 @@ void Game::startSearch(bool halveTT = true)
             }
         }
         if (currSearch >= 6){
-            // Percentage ( 0.732323 ) calculated with bench @22
-            nodesTmScale = 2.0 - ((double)nodesPerMoveTable[indexFromTo(moveSource(bestMove), moveTarget(bestMove))] / (double)nodes) * 1.365517675;    
+            // 1.242 felt cute, maybe it gains
+            nodesTmScale = 2.0 - ((double)nodesPerMoveTable[indexFromTo(moveSource(bestMove), moveTarget(bestMove))] / (double)nodes) * 1.242;    
         }
         // Check optim time quit
         if (getTime64() > startTime + optim * nodesTmScale) break;


### PR DESCRIPTION
Elo   | 6.79 +- 4.62 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8552 W: 2465 L: 2298 D: 3789
Penta | [150, 961, 1927, 1048, 190]
https://perseusopenbench.pythonanywhere.com/test/136/