### PR TITLE
History based moveloop pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -312,6 +312,10 @@ skipPruning:
                 skipQuiets = true;
                 continue;
             }
+            if (!PVNode && depth <= 4 && (isQuiet ? (currMoveScore - QUIETSCORE) : (currMoveScore - BADNOISYMOVE)) < ( -2048 * depth)){
+                skipQuiets = true;
+                continue;
+            }
         }
         else if (currMoveScore < COUNTERSCORE) continue;
         // assert (


### PR DESCRIPTION
Elo   | 23.81 +- 9.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1944 W: 589 L: 456 D: 899
Penta | [12, 202, 434, 289, 35]
https://perseusopenbench.pythonanywhere.com/test/208/