### PR TITLE
bench 3662095

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -188,7 +188,7 @@ TUNE_PARAM(doubleExtensionMargin, 26, 1, 50, 2.5, 0.002);
 TUNE_PARAM(singularSearchDepth, 7, 5, 10, .5, 0.002);
 
 // IIR values
-TUNE_PARAM(IIRDepth, 5, 3, 8, .5, 0.002);
+TUNE_PARAM(IIRDepth, 4, 3, 8, .5, 0.002);
 
 // FFP values
 TUNE_PARAM(futPruningMultiplier, 56, 30, 130, 5, 0.002);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -177,6 +177,11 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
     // Initialize the undoer
     UndoInfo undoer = UndoInfo(pos);
 
+    if (!excludedMove){
+        if (PVNode && depth >= IIRDepth() && !ttMove) --depth; 
+        if (cutNode && depth >= IIRDepth() && !ttMove) --depth; 
+    }
+
     if (inCheck)
     {
         ss->staticEval = eval = rawEval = noScore;
@@ -277,8 +282,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
     }
 
 skipPruning:
-    if (depth >= IIRDepth() && ttBound == hashNONE)
-        --depth; 
+    
 
     // Search
     const Score origAlpha = alpha;


### PR DESCRIPTION
Elo   | 4.45 +- 3.45 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 16948 W: 4953 L: 4736 D: 7259
Penta | [416, 1915, 3602, 2118, 423]
https://perseusopenbench.pythonanywhere.com/test/212/