### PR TITLE
Precomputed ks tables

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -114,32 +114,18 @@ constexpr Score COMPLEXITYBIAS = -18393;
 
 
 // Function to access the table values
-template <bool Interpolate>
 static inline S32 getKingSafetyFromTable(const std::array<int, KSTABLESIZE>& table, int x) {
     // Map x to the table index range
-    int index = ((x - MIN_X) * (KSTABLESIZE - 1) + (MAX_X - MIN_X)/2) / (MAX_X - MIN_X);
-    if (index < 0) return table[0];
-    if (index >= KSTABLESIZE - 1) return table[KSTABLESIZE - 1];
-
-    if constexpr (!Interpolate) {
-        return table[index];
-    } else {
-        // Linear interpolation
-        int nextIndex = index + 1;
-        double factor = static_cast<double>(x - (MIN_X + index * (MAX_X - MIN_X) / (KSTABLESIZE - 1))) /
-                        ((MAX_X - MIN_X) / (KSTABLESIZE - 1));
-        return static_cast<int>(table[index] * (1 - factor) + table[nextIndex] * factor);
-    }
+    S32 index = ((x - MIN_X) * (KSTABLESIZE - 1) + (MAX_X - MIN_X)/2) / (MAX_X - MIN_X);
+    return table[std::clamp(index, 0, KSTABLESIZE-1)];
 }
 
-template <bool Interpolate>
 int getKingSafetyMg(int x) {
-    return getKingSafetyFromTable<Interpolate>(kingSafetyMgTable, x);
+    return getKingSafetyFromTable(kingSafetyMgTable, x);
 }
 
-template <bool Interpolate>
 int getKingSafetyEg(int x) {
-    return getKingSafetyFromTable<Interpolate>(kingSafetyEgTable, x);
+    return getKingSafetyFromTable(kingSafetyEgTable, x);
 }
 
 static inline constexpr BitBoard centralFiles = files(2) | files(3) | files(4) | files(5);
@@ -788,10 +774,10 @@ Score pestoEval(Position *pos){
     dangerIndex[BLACK] += SAFETYINNERSHELTER * popcount(innerShelters[WHITE]);
     dangerIndex[BLACK] += SAFETYOUTERSHELTER * popcount(outerShelters[WHITE]);
 
-    const S32 mgWhiteDanger = getKingSafetyMg<false>(dangerIndex[WHITE].mg());
-    const S32 egWhiteDanger = getKingSafetyEg<false>(dangerIndex[WHITE].eg());
-    const S32 mgBlackDanger = getKingSafetyMg<false>(dangerIndex[BLACK].mg());
-    const S32 egBlackDanger = getKingSafetyEg<false>(dangerIndex[BLACK].eg());
+    const S32 mgWhiteDanger = getKingSafetyMg(dangerIndex[WHITE].mg());
+    const S32 egWhiteDanger = getKingSafetyEg(dangerIndex[WHITE].eg());
+    const S32 mgBlackDanger = getKingSafetyMg(dangerIndex[BLACK].mg());
+    const S32 egBlackDanger = getKingSafetyEg(dangerIndex[BLACK].eg());
     
     const PScore safety = PScore(mgWhiteDanger - mgBlackDanger, egWhiteDanger - egBlackDanger);
     score += safety;

--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -117,14 +117,13 @@ constexpr Score COMPLEXITYBIAS = -18393;
 template <bool Interpolate>
 static inline S32 getKingSafetyFromTable(const std::array<int, KSTABLESIZE>& table, int x) {
     // Map x to the table index range
-    int index = ((x - MIN_X) * (KSTABLESIZE - 1)) / (MAX_X - MIN_X);
-    if (index < 0) index = 0;
-    if (index >= KSTABLESIZE - 1) index = KSTABLESIZE - 1;
+    int index = ((x - MIN_X) * (KSTABLESIZE - 1) + (MAX_X - MIN_X)/2) / (MAX_X - MIN_X);
+    if (index < 0) return table[0];
+    if (index >= KSTABLESIZE - 1) return table[KSTABLESIZE - 1];
 
     if constexpr (!Interpolate) {
         return table[index];
     } else {
-        if (index == KSTABLESIZE - 1) return table[index];
         // Linear interpolation
         int nextIndex = index + 1;
         double factor = static_cast<double>(x - (MIN_X + index * (MAX_X - MIN_X) / (KSTABLESIZE - 1))) /

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -92,6 +92,16 @@ const PScore queenMob[28] = {
 extern const PScore* pestoTables[6];
 
 constexpr Score gamephaseInc[12] = { 0, 1, 1, 2, 4, 0, 0, 1, 1, 2, 4, 0 };
+
+//constexpr Score KSAMG = -2;
+constexpr double KSCALEMG = 879.0322265625;
+constexpr double KSBMG = 1.7232096195220947;
+constexpr double KSCMG = -3.021970748901367;
+// constexpr Score KSAEG = -71;
+constexpr double KSCALEEG = 1079.464599609375;
+constexpr double KSBEG = 2.0799951553344727;
+constexpr double KSCEG = 2.7020320892333984;
+
 extern PScore PSQTs[12][64];
 /**
 * @brief The initTables function initializes the material - positional tables

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -6,9 +6,9 @@
 #include "evaluation.h"
 #include "uci.h"
 #include "tt.h"
+#include <cmath>
 #include <iostream>
 #include <cstdlib>
-
 // Global var to debug the SE implementation
 S64 seCandidates = 0;
 U64 seActivations = 0;
@@ -202,7 +202,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
             eval = ttScore;
     }
     else if (excludedMove){
-        eval = ss->staticEval; // We already have the eval from the main search in the current ss entry
+        rawEval = eval = ss->staticEval; // We already have the eval from the main search in the current ss entry
         improvement = 0;
         improving = false;
         goto skipPruning;
@@ -410,8 +410,8 @@ skipPruning:
                     if (currMoveScore < QUIETSCORE) { 
                         if (cutNode) granularR += lmrBadNoisyCutNode();
                         granularR -= std::clamp((currMoveScore - BADNOISYMOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorA();
-                    }
-                    granularR -= std::clamp((currMoveScore - GOODNOISYMOVE - BADNOISYMOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorB();
+                                        }
+granularR -= std::clamp((currMoveScore - GOODNOISYMOVE - BADNOISYMOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorB();
                 }
                 // The function looked cool on desmos
                 granularR -= lmrCieckA() * improvement / (std::abs(improvement * lmrCieckB() / 1000) + lmrCieckC());

--- a/src/tables.cpp
+++ b/src/tables.cpp
@@ -49,6 +49,36 @@ BitBoard outerRing[64];
 BitBoard fiveSquare[64]; // The 5x5 square
 BitBoard kingShelter[2][64]; // The king shelter
 
+// Precomputed king safety tables
+
+std::array<S32, KSTABLESIZE> kingSafetyMgTable;
+std::array<S32, KSTABLESIZE> kingSafetyEgTable;
+
+// Helper function to compute the King Safety for Middlegame
+static inline int computeKingSafetyMg(double x) {
+    double f = x / (480.0 * 8.0);
+    f = KSBMG * f + KSCMG;
+    f = KSCALEMG / (std::exp(-f) + 1.0);
+    return static_cast<int>(f);
+}
+
+// Helper function to compute the King Safety for Endgame
+static inline int computeKingSafetyEg(double x) {
+    double f = x / (480.0 * 8.0);
+    f = KSBEG * f + KSCEG;
+    f = KSCALEEG / (std::exp(-f) + 1.0);
+    return static_cast<int>(f);
+}
+
+// Function to initialize the precomputed tables
+void initializeKingSafetyTables() {
+    for (int i = 0; i < KSTABLESIZE; ++i) {
+        double x = MIN_X + i * (MAX_X - MIN_X) / (KSTABLESIZE - 1);
+        kingSafetyMgTable[i] = computeKingSafetyMg(x);
+        kingSafetyEgTable[i] = computeKingSafetyEg(x);
+    }
+}
+
 // The LMR reduction table
 S32 reductionTable[2][64][64] = {{0}};
 S32 lmpMargin[128][2] = {{0}};
@@ -90,6 +120,8 @@ void initLMRTable(){
  * @brief The initEvalTables function initializes the evaluation tables.
  */
 void initEvalTables() {
+    // Initialize king safety tables
+    initializeKingSafetyTables();
     //BitBoard squaresToLeft[64];
     for (Square square = a8; square < noSquare; square++) {
         BitBoard res = ranks(rankOf(square));

--- a/src/tables.cpp
+++ b/src/tables.cpp
@@ -56,7 +56,7 @@ std::array<S32, KSTABLESIZE> kingSafetyEgTable;
 
 // Helper function to compute the King Safety for Middlegame
 static inline int computeKingSafetyMg(double x) {
-    double f = x / (480.0 * 8.0);
+    double f = x / 480.0;
     f = KSBMG * f + KSCMG;
     f = KSCALEMG / (std::exp(-f) + 1.0);
     return static_cast<int>(f);
@@ -64,7 +64,7 @@ static inline int computeKingSafetyMg(double x) {
 
 // Helper function to compute the King Safety for Endgame
 static inline int computeKingSafetyEg(double x) {
-    double f = x / (480.0 * 8.0);
+    double f = x / 480.0;
     f = KSBEG * f + KSCEG;
     f = KSCALEEG / (std::exp(-f) + 1.0);
     return static_cast<int>(f);

--- a/src/tables.h
+++ b/src/tables.h
@@ -33,9 +33,9 @@ extern S32 reductionTable[2][64][64];
 extern S32 lmpMargin[128][2];
 
 
-constexpr S32 KSTABLESIZE = 64;
-constexpr S32 MIN_X = -12000;
-constexpr S32 MAX_X = 6000;
+constexpr S32 KSTABLESIZE = 128;
+constexpr S32 MIN_X = -2500;
+constexpr S32 MAX_X = 16500;
 extern std::array<S32, KSTABLESIZE> kingSafetyMgTable;
 extern std::array<S32, KSTABLESIZE> kingSafetyEgTable;
 

--- a/src/tables.h
+++ b/src/tables.h
@@ -2,6 +2,7 @@
 
 #include "types.h"
 #include "constants.h"
+#include <array>
 #define RESOLUTION 1000
 
 //tropism
@@ -30,6 +31,14 @@ extern HashKey repetitionTable[512];
 // The LMR reduction table
 extern S32 reductionTable[2][64][64];
 extern S32 lmpMargin[128][2];
+
+
+constexpr S32 KSTABLESIZE = 64;
+constexpr S32 MIN_X = -12000;
+constexpr S32 MAX_X = 6000;
+extern std::array<S32, KSTABLESIZE> kingSafetyMgTable;
+extern std::array<S32, KSTABLESIZE> kingSafetyEgTable;
+
 
 /**
  * @brief The initLMRTable function initializes the LMR reduction table

--- a/src/tables.h
+++ b/src/tables.h
@@ -33,9 +33,9 @@ extern S32 reductionTable[2][64][64];
 extern S32 lmpMargin[128][2];
 
 
-constexpr S32 KSTABLESIZE = 128;
-constexpr S32 MIN_X = -2500;
-constexpr S32 MAX_X = 16500;
+constexpr S32 KSTABLESIZE = 256;
+constexpr S32 MIN_X = -16000;
+constexpr S32 MAX_X = 18000;
 extern std::array<S32, KSTABLESIZE> kingSafetyMgTable;
 extern std::array<S32, KSTABLESIZE> kingSafetyEgTable;
 


### PR DESCRIPTION
Elo   | 5.63 +- 4.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 12164 W: 3642 L: 3445 D: 5077
Penta | [286, 1387, 2584, 1494, 331]
https://perseusopenbench.pythonanywhere.com/test/267/