### PR TITLE
Thingy++

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -196,7 +196,8 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
     {
         // Check if the eval is stored in the TT
         rawEval = tte->eval != noScore ? tte->eval : evaluate();
-        eval = ss->staticEval = correctStaticEval(pos, rawEval);
+        bool isTTCapture = pos.pieceOn(ttMove) != NOPIECE;
+        eval = ss->staticEval = isTTCapture ? rawEval : correctStaticEval(pos, rawEval);
         // Also, we might be able to use the score as a better eval
         if (ttScore != noScore && (ttBound == hashEXACT || (ttBound == hashUPPER && ttScore < eval) || (ttBound == hashLOWER && ttScore > eval)))
             eval = ttScore;
@@ -542,7 +543,8 @@ Score Game::quiescence(Score alpha, Score beta, SStack *ss)
     }
     else if (ttHit){
         rawEval = tte->eval != noScore ? tte->eval : evaluate();
-        ss->staticEval = bestScore = correctStaticEval(pos, rawEval);
+        bool isTTCapture = pos.pieceOn(ttMove) != NOPIECE;
+        eval = ss->staticEval = isTTCapture ? rawEval : correctStaticEval(pos, rawEval);
         if (ttScore != noScore && (ttBound == hashEXACT || (ttBound == hashUPPER && ttScore < bestScore) || (ttBound == hashLOWER && ttScore > bestScore)))
             bestScore = ttScore;
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -190,7 +190,6 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
         goto skipPruning;
     }
     
-
     // Get static eval of the position
     if (ttHit)
     {
@@ -544,7 +543,7 @@ Score Game::quiescence(Score alpha, Score beta, SStack *ss)
     else if (ttHit){
         rawEval = tte->eval != noScore ? tte->eval : evaluate();
         bool isTTCapture = pos.pieceOn(ttMove) != NOPIECE;
-        eval = ss->staticEval = isTTCapture ? rawEval : correctStaticEval(pos, rawEval);
+        ss->staticEval = bestScore = isTTCapture ? rawEval : correctStaticEval(pos, rawEval);
         if (ttScore != noScore && (ttBound == hashEXACT || (ttBound == hashUPPER && ttScore < bestScore) || (ttBound == hashLOWER && ttScore > bestScore)))
             bestScore = ttScore;
     }


### PR DESCRIPTION
Elo   | 7.20 +- 4.83 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8256 W: 2473 L: 2302 D: 3481
Penta | [176, 905, 1815, 1036, 196]
https://perseusopenbench.pythonanywhere.com/test/277/