### PR TITLE
bench 4328000

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -195,8 +195,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
     {
         // Check if the eval is stored in the TT
         rawEval = tte->eval != noScore ? tte->eval : evaluate();
-        bool isTTCapture = pos.pieceOn(ttMove) != NOPIECE;
-        eval = ss->staticEval = isTTCapture ? rawEval : correctStaticEval(pos, rawEval);
+        eval = ss->staticEval = ttMove ? rawEval : correctStaticEval(pos, rawEval);
         // Also, we might be able to use the score as a better eval
         if (ttScore != noScore && (ttBound == hashEXACT || (ttBound == hashUPPER && ttScore < eval) || (ttBound == hashLOWER && ttScore > eval)))
             eval = ttScore;
@@ -542,8 +541,7 @@ Score Game::quiescence(Score alpha, Score beta, SStack *ss)
     }
     else if (ttHit){
         rawEval = tte->eval != noScore ? tte->eval : evaluate();
-        bool isTTCapture = pos.pieceOn(ttMove) != NOPIECE;
-        ss->staticEval = bestScore = isTTCapture ? rawEval : correctStaticEval(pos, rawEval);
+        ss->staticEval = bestScore = ttMove ? rawEval : correctStaticEval(pos, rawEval);
         if (ttScore != noScore && (ttBound == hashEXACT || (ttBound == hashUPPER && ttScore < bestScore) || (ttBound == hashLOWER && ttScore > bestScore)))
             bestScore = ttScore;
     }


### PR DESCRIPTION
Now with non bugged elo:
Passed STC:
Elo   | 7.41 +- 4.93 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7972 W: 2372 L: 2202 D: 3398
Penta | [154, 916, 1726, 986, 204]
https://perseusopenbench.pythonanywhere.com/test/291/
Passed LTC:
Elo   | 3.58 +- 2.84 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20480 W: 5676 L: 5465 D: 9339
Penta | [288, 2370, 4745, 2517, 320]
https://perseusopenbench.pythonanywhere.com/test/292/