### PR TITLE
Pawn eval hash

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -137,8 +137,7 @@ void Game::reset(){
     }
 
     // Clear pawn hash table
-    memset(whitePawnEvalHash, 0, sizeof(whitePawnEvalHash));
-    memset(blackPawnEvalHash, 0, sizeof(whitePawnEvalHash));
+    memset(pawnEvalHash, 0, sizeof(pawnEvalHash));
 #endif
 
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -137,9 +137,8 @@ void Game::reset(){
     }
 
     // Clear pawn hash table
-    for (size_t i = 0; i < PAWNHASHSIZE; i++){
-        pawnEvalHash[i] = PawnEvalHashEntry();
-    }
+    memset(whitePawnEvalHash, 0, sizeof(whitePawnEvalHash));
+    memset(blackPawnEvalHash, 0, sizeof(whitePawnEvalHash));
 #endif
 
 }

--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -135,6 +135,11 @@ void Game::reset(){
         tt[i].eval = noScore;
         tt[i].flags = hashINVALID;
     }
+
+    // Clear pawn hash table
+    for (size_t i = 0; i < PAWNHASHSIZE; i++){
+        pawnEvalHash[i] = PawnEvalHashEntry();
+    }
 #endif
 
 }

--- a/src/Position.h
+++ b/src/Position.h
@@ -40,6 +40,7 @@ struct Position{
     U8 castle;
     HashKey hashKey;
     HashKey pawnHashKey;
+    HashKey whitePawnsHashKey; // No need to store the black one, we can infer it by XORing
     HashKey nonPawnKeys[2];
     HashKey minorKey;
     PScore psqtScore; // PSQT score, incrementally updated
@@ -62,6 +63,12 @@ struct Position{
      * @note This function is called by the constructors. Otherwise the hash gets incrementally updated.
      */
     HashKey generatePawnHashKey();
+
+    /**
+     * @brief The Position::generateWhitePawnHashKey function generates the hash key of the white pawn structure from scratch.
+     * @note This function is called by the constructors. Otherwise the hash gets incrementally updated.
+     */
+    HashKey generateWhitePawnHashKey();
 
     /** 
      * @brief The Position::generateNonPawnHashKey function generates the hash key of the non pawn structure from scratch, for a given side.
@@ -235,6 +242,7 @@ struct UndoInfo {
     // Irreversible information
     HashKey hashKey;
     HashKey pawnsHashKey;
+    HashKey whitePawnsHashKey;
     HashKey nonPawnsHashKey[2];
     HashKey minorHashKey;
     Square enPassant;

--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -1,6 +1,7 @@
 #include "evaluation.h"
 #include "tables.h"
 #include "tt.h"
+#include "zobrist.h"
 #include "movegen.h"
 #include "types.h"
 #include <iostream>
@@ -12,7 +13,8 @@
 
 PScore PSQTs[12][64];
 
-PawnEvalHashEntry pawnEvalHash[PAWNHASHSIZE];
+PawnEvalHashEntry whitePawnEvalHash[PAWNHASHSIZE];
+PawnEvalHashEntry blackPawnEvalHash[PAWNHASHSIZE];
 
 const PScore* pestoTables[6] = {
     pawnTable,
@@ -285,6 +287,86 @@ static inline BitBoard pawnSpanPawns(BitBoard movers, BitBoard blockers){
     }
 }
 
+template <bool side>
+inline PScore pawnEval(HashKey hashKey, BitBoard ourPawns, BitBoard theirPawns, BitBoard doubledPawns, BitBoard theirPawnFiles, BitBoard protectedPawns, BitBoard pawnBlockage, BitBoard occ, S32& passedCount){
+    // Select the correct entry
+    PawnEvalHashEntry* table;
+    if constexpr (side == WHITE) table = whitePawnEvalHash;
+    else table = blackPawnEvalHash;
+    // Try probing for the correct side here
+    PawnEvalHashEntry& entry = table[hashKey & 0x3FFFF];
+    // Init the score
+    PScore pawnScore;
+    // Check
+    if (false && entry.hash == hashKey){
+        BitBoard passers = entry.passers;
+        passedCount += popcount(passers); // May already be nonzero
+        pawnScore = entry.score;
+        while (passers){
+            Square sq = popLsb(passers);
+            BitBoard sqb = squareBB(sq);
+            // Give bonus for how many squares the pawn can advance
+            BitBoard passedPath = advancePathMasked<side>(sqb, ~occ);
+            pawnScore += PASSEDPATHBONUS * popcount(passedPath);
+        }
+    }
+    else {
+        BitBoard pieces = ourPawns;
+        BitBoard passers = 0ULL;
+        while (pieces) {
+            // Evaluate isolated, backward, doubled pawns and connected pawns
+            const Square sq = popLsb(pieces);
+            const BitBoard sqb = squareBB(sq);
+            const U8 rank = side ? rankOf(sq) : 7 - rankOf(sq);
+            bool doubled = doubledPawns & sqb;
+            bool isolated = !(isolatedPawnMask[sq] & ourPawns);
+            bool pawnOpposed = !(theirPawnFiles & sqb);
+            bool supported = protectedPawns & sqb;
+            bool advancable = !(pawnBlockage & (side ? south(sqb) : north(sqb)));
+            bool phal = phalanx[sq] & ourPawns;
+            bool candidatePassed = !(passedPawnMask[side][sq] & theirPawns);
+            
+            bool backward = !( // If the pawn
+                (backwardPawnMask[side][sq] & ourPawns) // If the pawn is doesn't have behind or adjacent pawns in adjacent files
+                || advancable // If the pawn can't advance (blocked by enemy pawn or enemy pawn capture square)
+            );
+            // Check if the pawn is doubled
+            if (isolated){
+                if (doubled && pawnOpposed) pawnScore -= DOUBLEISOLATEDPEN;
+                else pawnScore -= ISOLATEDPEN;
+            }
+            else if (backward) pawnScore -= BACKWARDPEN;
+
+            if (doubled && !supported) pawnScore -= DOUBLEDPEN;
+            else if (supported && phal){
+                pawnScore += SUPPORTEDPHALANX;
+                pawnScore += R_SUPPORTEDPHALANX * (rank - 2);
+            }
+            else if (advancable && phal){
+                pawnScore += ADVANCABLEPHALANX;
+                pawnScore += R_ADVANCABLEPHALANX * (rank - 2);
+            }
+            if (candidatePassed){
+                // Give bonus for how close the pawn is to the promotion square
+                pawnScore += passedRankBonus[rank];
+                // Give bonus for how many squares the pawn can advance
+                BitBoard passedPath = advancePathMasked<side>(sqb, ~occ);
+                pawnScore += PASSEDPATHBONUS * popcount(passedPath);
+                // Bonus for connected or supported passed pawns
+                if (supported) pawnScore += SUPPORTEDPASSER;
+                // Add to passers and count
+                passers |= sqb;
+                ++passedCount;
+            }
+        }
+        // Save
+        entry.hash = hashKey;
+        entry.score = pawnScore;
+        entry.passers = passers;
+    }
+    return pawnScore;
+}
+
 Score pestoEval(Position *pos){
     auto const& bb = pos->bitboards;
     auto const& occ = pos->occupancies;
@@ -492,117 +574,11 @@ Score pestoEval(Position *pos){
 
     BitBoard doubledPawns[2] = { bb[P] & (bb[P] << 8), bb[p] & (bb[p] >> 8) };
     BitBoard pawnFiles[2] = { filesFromBB(bb[P]), filesFromBB(bb[p]) };
-    // White pawns
-    BitBoard pieces = bb[P];
 
-    // Probe pawn eval hash
-    PawnEvalHashEntry& pawnEntry = pawnEvalHash[pos->pawnHashKey & 0x3FFF];
-    if (pawnEntry.passersCount != -1 && pawnEntry.hash == pos->pawnHashKey){
-        score += pawnEntry.score;
-        passedCount = pawnEntry.passersCount;
-    }
-    else {
-        PScore pawnScore = PScore(0,0);
-        while (pieces){
-            // Evaluate isolated, backward, doubled pawns and connected pawns
-            const Square sq = popLsb(pieces);
-            const BitBoard sqb = squareBB(sq);
-            const U8 rank = 7 - rankOf(sq);
-            bool doubled = doubledPawns[WHITE] & squareBB(sq);
-            bool isolated = !(isolatedPawnMask[sq] & bb[P]);
-            bool pawnOpposed = !(pawnFiles[BLACK] & sqb);
-            bool supported = protectedPawns[WHITE] & sqb;
-            bool advancable = !(pawnBlockage[WHITE] & north(sqb));
-            bool phal = phalanx[sq] & bb[P];
-            bool candidatePassed = !(passedPawnMask[WHITE][sq] & bb[p]);
-            
-            bool backward = !( // If the pawn
-                (backwardPawnMask[WHITE][sq] & bb[P]) // If the pawn is doesn't have behind or adjacent pawns in adjacent files
-                || advancable // If the pawn can't advance (blocked by enemy pawn or enemy pawn capture square)
-            );
-            // Check if the pawn is doubled
-            if (isolated){
-                if (doubled && pawnOpposed) pawnScore -= DOUBLEISOLATEDPEN;
-                else pawnScore -= ISOLATEDPEN;
-            }
-            else if (backward) pawnScore -= BACKWARDPEN;
-
-            if (doubled && !supported) pawnScore -= DOUBLEDPEN;
-            else if (supported && phal){
-                pawnScore += SUPPORTEDPHALANX;
-                pawnScore += R_SUPPORTEDPHALANX * (rank - 2);
-            }
-            else if (advancable && phal){
-                pawnScore += ADVANCABLEPHALANX;
-                pawnScore += R_ADVANCABLEPHALANX * (rank - 2);
-            }
-            if (candidatePassed){
-                BitBoard passedPath = advancePathMasked<WHITE>(sqb, ~bb[BOTH]);
-                // Give bonus for how close the pawn is to the promotion square
-                pawnScore += passedRankBonus[rank];
-                // Give bonus for how many squares the pawn can advance
-                pawnScore += PASSEDPATHBONUS * popcount(passedPath);
-                // Bonus for connected or supported passed pawns
-                if (supported){
-                    pawnScore += SUPPORTEDPASSER;
-                }
-                ++passedCount;
-            }
-        }
-
-        // Black pawns
-        pieces = bb[p];
-        while (pieces){
-            // Evaluate isolated, backward, doubled pawns and connected pawns
-            const Square sq = popLsb(pieces);
-            const BitBoard sqb = squareBB(sq);
-            const U8 rank = rankOf(sq);
-            bool doubled = doubledPawns[BLACK] & squareBB(sq);
-            bool isolated = !(isolatedPawnMask[sq] & bb[p]);
-            bool pawnOpposed = !(pawnFiles[WHITE] & sqb);
-            bool supported = protectedPawns[BLACK] & sqb;
-            bool advancable = !(pawnBlockage[BLACK] & south(sqb));
-            bool phal = phalanx[sq] & bb[p];
-            bool candidatePassed = !(passedPawnMask[BLACK][sq] & bb[P]);
-            
-            bool backward = !( // If the pawn
-                (backwardPawnMask[BLACK][sq] & bb[p]) // If the pawn is doesn't have behind or adjacent pawns in adjacent files
-                || advancable // If the pawn can't advance (blocked by enemy pawn or enemy pawn capture square)
-            );
-            // Check if the pawn is doubled
-            if (isolated){
-                if (doubled && pawnOpposed) pawnScore += DOUBLEISOLATEDPEN;
-                else pawnScore += ISOLATEDPEN;
-            }
-            else if (backward) pawnScore += BACKWARDPEN;
-
-            if (doubled && !supported) pawnScore += DOUBLEDPEN;
-            else if (supported && phal){
-                pawnScore -= SUPPORTEDPHALANX;
-                pawnScore -= R_SUPPORTEDPHALANX * (rank - 2);
-            }
-            else if (advancable && phal){
-                pawnScore -= ADVANCABLEPHALANX;
-                pawnScore -= R_ADVANCABLEPHALANX * (rank - 2);
-            }
-            if (candidatePassed){
-                BitBoard passedPath = advancePathMasked<BLACK>(sqb, ~bb[BOTH]);
-                // Give bonus for how close the pawn is to the promotion square
-                pawnScore -= passedRankBonus[rank];
-                // Give bonus for how many squares the pawn can advance
-                pawnScore -= PASSEDPATHBONUS * popcount(passedPath);
-                // Bonus for connected or supported passed pawns
-                if (supported) pawnScore -= SUPPORTEDPASSER;
-                ++passedCount;
-            }
-        }
-        // Store
-        pawnEntry.score = pawnScore;
-        pawnEntry.hash = pos->pawnHashKey;
-        pawnEntry.passersCount = passedCount;
-        // Add pawn score
-        score += pawnScore;
-    }
+    const HashKey whitePawnsHashKey = pos->whitePawnsHashKey;
+    const HashKey blackPawnsHashKey = pos->pawnHashKey ^ whitePawnsHashKey ^ enPassantKeysTable[pos->enPassant];
+    score += pawnEval<WHITE>(whitePawnsHashKey, bb[P], bb[p], doubledPawns[WHITE], pawnFiles[BLACK], protectedPawns[WHITE], pawnBlockage[WHITE], occ[BOTH], passedCount);
+    score -= pawnEval<BLACK>(blackPawnsHashKey, bb[p], bb[P], doubledPawns[BLACK], pawnFiles[WHITE], protectedPawns[BLACK], pawnBlockage[BLACK], occ[BOTH], passedCount);
     
     // Calculate king safety
     // King shield. The inner shield is direcly in front of the king so it should be at least supported by the king itself

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -102,21 +102,16 @@ constexpr double KSCALEEG = 1079.464599609375;
 constexpr double KSBEG = 2.0799951553344727;
 constexpr double KSCEG = 2.7020320892333984;
 
-#define PAWNHASHSIZE 16384ULL
+#define PAWNHASHSIZE 262144ULL
 
 struct PawnEvalHashEntry {
     U64 hash;
     PScore score;
-    S32 passersCount; // This can be shrinked to add more stuff and keep the alignement
-
-    PawnEvalHashEntry(){
-        hash = 0ULL;
-        score = PScore(0,0);
-        passersCount = -1; // Signal that entry is empty
-    }
+    BitBoard passers; // This can be shrinked to add more stuff and keep the alignement
 };
 
-extern PawnEvalHashEntry pawnEvalHash[PAWNHASHSIZE];
+extern PawnEvalHashEntry whitePawnEvalHash[PAWNHASHSIZE];
+extern PawnEvalHashEntry blackPawnEvalHash[PAWNHASHSIZE];
 
 extern PScore PSQTs[12][64];
 /**

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -110,8 +110,7 @@ struct PawnEvalHashEntry {
     BitBoard passers; // This can be shrinked to add more stuff and keep the alignement
 };
 
-extern PawnEvalHashEntry whitePawnEvalHash[PAWNHASHSIZE];
-extern PawnEvalHashEntry blackPawnEvalHash[PAWNHASHSIZE];
+extern PawnEvalHashEntry pawnEvalHash[PAWNHASHSIZE];
 
 extern PScore PSQTs[12][64];
 /**

--- a/src/evaluation.h
+++ b/src/evaluation.h
@@ -102,6 +102,22 @@ constexpr double KSCALEEG = 1079.464599609375;
 constexpr double KSBEG = 2.0799951553344727;
 constexpr double KSCEG = 2.7020320892333984;
 
+#define PAWNHASHSIZE 16384ULL
+
+struct PawnEvalHashEntry {
+    U64 hash;
+    PScore score;
+    S32 passersCount; // This can be shrinked to add more stuff and keep the alignement
+
+    PawnEvalHashEntry(){
+        hash = 0ULL;
+        score = PScore(0,0);
+        passersCount = -1; // Signal that entry is empty
+    }
+};
+
+extern PawnEvalHashEntry pawnEvalHash[PAWNHASHSIZE];
+
 extern PScore PSQTs[12][64];
 /**
 * @brief The initTables function initializes the material - positional tables

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -93,6 +93,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, const bool cutNode, SSt
 
     assert(pos.hashKey == pos.generateHashKey());
     assert(pos.pawnHashKey == pos.generatePawnHashKey());
+    assert(pos.whitePawnsHashKey == pos.generateWhitePawnHashKey());
     assert(pos.nonPawnKeys[WHITE] == pos.generateNonPawnHashKey(WHITE));
     assert(pos.nonPawnKeys[BLACK] == pos.generateNonPawnHashKey(BLACK));
     assert(pos.minorKey == pos.generateMinorHashKey());


### PR DESCRIPTION
Elo   | 13.65 +- 7.02 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3718 W: 1169 L: 1023 D: 1526
Penta | [65, 373, 867, 459, 95]
https://perseusopenbench.pythonanywhere.com/test/295/