### PR TITLE
Negative extension on failed singular cutnodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -370,7 +370,7 @@ skipPruning:
                         undo(undoer, currMove);
                         return singularBeta;
                     }
-                    else if (ttScore >= beta){
+                    else if (ttScore >= beta || cutNode){
                         extension = -1;
                     }
                     


### PR DESCRIPTION
Elo   | 3.09 +- 2.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 30342 W: 8661 L: 8391 D: 13290
Penta | [581, 3633, 6552, 3745, 660]
https://perseusopenbench.pythonanywhere.com/test/326/