### PR TITLE
Fix TempoInFormula

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -819,7 +819,7 @@ Score pestoEval(Position *pos){
     dangerIndex[BLACK] += SAFETYINNERSHELTER * popcount(innerShelters[WHITE]);
     dangerIndex[BLACK] += SAFETYOUTERSHELTER * popcount(outerShelters[WHITE]);
     const S32 sign = 1 - 2 * pos->side;
-    dangerIndex[sign] += KSTEMPO;
+    dangerIndex[pos->side] += KSTEMPO;
 
 
     const S32 mgWhiteDanger = getKingSafetyMg(dangerIndex[WHITE].mg());


### PR DESCRIPTION
Nonregr
Elo   | 0.97 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 35198 W: 9795 L: 9697 D: 15706
Penta | [669, 4256, 7663, 4330, 681]
https://perseusopenbench.pythonanywhere.com/test/338/