### PR TITLE
Add Triplet Correction History / UberCorrection History

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -117,8 +117,7 @@ void Game::reset(){
     memset(continuationHistoryTable, 0, sizeof(continuationHistoryTable));
     memset(pawnsCorrHist, 0, sizeof(pawnsCorrHist));
     memset(nonPawnsCorrHist, 0, sizeof(nonPawnsCorrHist));
-    memset(minorCorrHist, 0, sizeof(minorCorrHist));
-    memset(rookPawnCorrHist, 0, sizeof(rookPawnCorrHist));
+    memset(tripletCorrHist, 0, sizeof(tripletCorrHist));
 
 
     // Clear pv len and pv table

--- a/src/Position.h
+++ b/src/Position.h
@@ -42,8 +42,7 @@ struct Position{
     HashKey hashKey;
     HashKey pawnHashKey;
     HashKey nonPawnKeys[2];
-    HashKey minorKey;
-    HashKey rookPawnKey;
+    HashKey ptKeys[6];
     PScore psqtScores[4]; // PSQT score, incrementally updated. White / Black - file <= 3 / >= 4
 
     // The default constructor instantiates the position with the standard chess starting position.
@@ -72,16 +71,12 @@ struct Position{
     HashKey generateNonPawnHashKey(const bool side);
 
     /**
-     * @brief The Position::generateMinorHashKey function generates the hash key of the minor pieces from scratch.
+     * @brief The Position::generatePtHashKey function generates the hash key for a single pt from scratch.
+     * @tparam The pt to generate
      * @note This function is called by the constructors. Otherwise the hash gets incrementally updated.
      */
-    HashKey generateMinorHashKey();
-
-    /** 
- * @brief The Position::generateRookPawnHashKey function generates the hash key of the rook-pawn-king structure.
- * @note This function is called by the constructors. Otherwise the hash gets incrementally updated.
- */
-    HashKey generateRookPawnHashKey();
+    template <Piece pt>
+    HashKey generatePtHashKey();
 
     /**
      * @brief The Position::print function prints the position to stdout.
@@ -245,8 +240,7 @@ struct UndoInfo {
     HashKey hashKey;
     HashKey pawnsHashKey;
     HashKey nonPawnsHashKey[2];
-    HashKey minorHashKey;
-    HashKey rookPawnHashKey;
+    HashKey ptHashKey[6];
     Square enPassant;
     U8 castle;
     U8 fiftyMove;

--- a/src/history.h
+++ b/src/history.h
@@ -25,8 +25,8 @@ extern S32 continuationHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES * NUM_S
 // Correction History
 extern S32 pawnsCorrHist[2][CORRHISTSIZE];
 extern S32 nonPawnsCorrHist[2][2][CORRHISTSIZE];
-extern S32 minorCorrHist[2][CORRHISTSIZE]; // stm - hash
-extern S32 rookPawnCorrHist[2][CORRHISTSIZE]; // stm - hash
+
+extern S32 tripletCorrHist[10][2][CORRHISTSIZE]; // 10 is the number of triplet indexing of type KXY, with X and Y satisfying X != K, Y != K, X != Y
 
 struct SStack {
     Move excludedMove = 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -95,8 +95,13 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
     assert(pos.pawnHashKey == pos.generatePawnHashKey());
     assert(pos.nonPawnKeys[WHITE] == pos.generateNonPawnHashKey(WHITE));
     assert(pos.nonPawnKeys[BLACK] == pos.generateNonPawnHashKey(BLACK));
-    assert(pos.minorKey == pos.generateMinorHashKey());
-    assert(pos.rookPawnKey == pos.generateRookPawnHashKey());
+    assert(pos.ptKeys[P] == pos.generatePtHashKey<P>());
+    assert(pos.ptKeys[N] == pos.generatePtHashKey<N>());
+    assert(pos.ptKeys[B] == pos.generatePtHashKey<B>());
+    assert(pos.ptKeys[R] == pos.generatePtHashKey<R>());
+    assert(pos.ptKeys[Q] == pos.generatePtHashKey<Q>());
+    assert(pos.ptKeys[K] == pos.generatePtHashKey<K>());
+
     // Ply overflow
     if (ply >= maxPly)
         return evaluate();

--- a/src/zobrist.cpp
+++ b/src/zobrist.cpp
@@ -5,8 +5,6 @@
 HashKey pieceKeysTable[12][64];
 HashKey pawnKeysTable[12][64];
 HashKey nonPawnKeysTable[12][64];
-HashKey minorKeysTable[12][64];
-HashKey rookPawnKeysTable[12][64];
 // random enPassant keys
 HashKey enPassantKeysTable[65];
 // random castling keys
@@ -24,33 +22,23 @@ void initHashKeys(){
             switch (i % 6){
                 case 0:
                     pawnKeysTable[i][j] = pieceKeysTable[i][j];
-                    minorKeysTable[i][j] = 0;
                     nonPawnKeysTable[i][j] = 0;
-                    rookPawnKeysTable[i][j] = pieceKeysTable[i][j];
                     break;
                 case 1: case 2:
                     pawnKeysTable[i][j] = 0;
-                    minorKeysTable[i][j] = pieceKeysTable[i][j];
                     nonPawnKeysTable[i][j] = pieceKeysTable[i][j];
-                    rookPawnKeysTable[i][j] = 0;
                     break;
                 case 3:
                     pawnKeysTable[i][j] = 0;
-                    minorKeysTable[i][j] = 0;
                     nonPawnKeysTable[i][j] = pieceKeysTable[i][j];
-                    rookPawnKeysTable[i][j] = pieceKeysTable[i][j];
                     break;
                 case 4:
                     pawnKeysTable[i][j] = 0;
-                    minorKeysTable[i][j] = 0;
                     nonPawnKeysTable[i][j] = pieceKeysTable[i][j];
-                    rookPawnKeysTable[i][j] = 0;
                     break;
                 case 5:
                     pawnKeysTable[i][j] = 0;
-                    minorKeysTable[i][j] = pieceKeysTable[i][j];
                     nonPawnKeysTable[i][j] = pieceKeysTable[i][j];
-                    rookPawnKeysTable[i][j] = pieceKeysTable[i][j];
                     break;
             }
         }

--- a/src/zobrist.h
+++ b/src/zobrist.h
@@ -5,8 +5,6 @@
 extern HashKey pieceKeysTable[12][64];
 extern HashKey pawnKeysTable[12][64];
 extern HashKey nonPawnKeysTable[12][64];
-extern HashKey minorKeysTable[12][64];
-extern HashKey rookPawnKeysTable[12][64];
 // random enPassant keys
 extern HashKey enPassantKeysTable[65];
 // random castling keys


### PR DESCRIPTION
Generalization of common correction techniques such as major / minor and an original KRP (also called rook endgames corrhist).
Try all the KXY triplets, with X != Y, and both X and Y different than K.
This also is very nice from a tunability standpoint.
(Some "mean shift" effect are being suspected with the introduction of this many corrhists, but they seem to be outweighted by the sheer gain).

Passed STC:
Elo   | 18.82 +- 8.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2698 W: 873 L: 727 D: 1098
Penta | [43, 289, 573, 367, 77]
https://perseusopenbench.pythonanywhere.com/test/361/

Passed LTC:
Elo   | 21.94 +- 8.72 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2014 W: 641 L: 514 D: 859
Penta | [15, 195, 478, 286, 33]
https://perseusopenbench.pythonanywhere.com/test/362/

bench 3370647