### PR TITLE
Always search at least one move in pvs

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -303,25 +303,27 @@ skipPruning:
         Move currMove = onlyMove(moveList.moves[i]);
         if (sameMovePos(currMove, excludedMove)) continue;
         const bool isQuiet = okToReduce(currMove);
-        if (!skipQuiets) { 
-            if (!PVNode && moveSearched >= lmpMargin[depth][improving]) skipQuiets = true;
-            if (!PVNode
-                && depth <= 8
-                && !inCheck
-                && bestScore > -KNOWNWIN
-                && std::abs(alpha) < KNOWNWIN
-                && isQuiet
-                && ss->staticEval + futPruningAdd() + futPruningMultiplier() * depth <= alpha)
-            {
-                skipQuiets = true;
-                continue;
+        if (moveSearched){
+            if (!skipQuiets) { 
+                if (!PVNode && moveSearched >= lmpMargin[depth][improving]) skipQuiets = true;
+                if (!PVNode
+                    && depth <= 8
+                    && !inCheck
+                    && bestScore > -KNOWNWIN
+                    && std::abs(alpha) < KNOWNWIN
+                    && isQuiet
+                    && ss->staticEval + futPruningAdd() + futPruningMultiplier() * depth <= alpha)
+                {
+                    skipQuiets = true;
+                    continue;
+                }
+                if (!PVNode && depth <= 4 && (isQuiet ? (currMoveScore - QUIETSCORE) : (currMoveScore - BADNOISYMOVE)) < ( historyPruningMultiplier() * depth) + historyPruningBias()){
+                    skipQuiets = true;
+                    continue;
+                }
             }
-            if (!PVNode && depth <= 4 && (isQuiet ? (currMoveScore - QUIETSCORE) : (currMoveScore - BADNOISYMOVE)) < ( historyPruningMultiplier() * depth) + historyPruningBias()){
-                skipQuiets = true;
-                continue;
-            }
+            else if (currMoveScore < COUNTERSCORE) continue;
         }
-        else if (currMoveScore < COUNTERSCORE) continue;
         // assert (
         //     i != 0 || !excludedMove ||
         //     (excludedMove == currMove)


### PR DESCRIPTION
Elo   | 3.28 +- 2.63 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 26976 W: 7797 L: 7542 D: 11637
Penta | [532, 3138, 5926, 3327, 565]
https://perseusopenbench.pythonanywhere.com/test/376/
bench 3445600