### PR TITLE
Clamp Maximum Corrhist Update

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -97,8 +97,9 @@ Score correctStaticEval(Position& pos, const Score eval) {
 }
 
 static inline void updateSingleCorrHist(S32& entry, const S32 bonus, const S32 weight){
-    entry = (entry * (256 - weight) + bonus * weight) / 256;
-    entry = static_cast<Score>(std::clamp(entry, -MAXCORRHIST, MAXCORRHIST));
+    S32 newValue = (entry * (256 - weight) + bonus * weight) / 256;
+    newValue = std::clamp(newValue, entry - MAXCORRHISTUPDATE, entry + MAXCORRHISTUPDATE);
+    entry = std::clamp(newValue, -MAXCORRHIST, MAXCORRHIST);
 }
 
 void updateCorrHist(Position& pos, const Score bonus, const Depth depth){

--- a/src/history.h
+++ b/src/history.h
@@ -19,9 +19,11 @@ extern Move counterMoveTable[NUM_SQUARES * NUM_SQUARES];
 // Continuation History table
 extern S32 continuationHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES * NUM_SQUARES];
 
-#define CORRHISTSIZE 16384
-#define CORRHISTSCALE 256
-#define MAXCORRHIST (CORRHISTSCALE * 32)
+constexpr S32 CORRHISTSIZE = 16384;
+constexpr S32 CORRHISTSCALE = 256;
+constexpr S32 MAXCORRHIST = CORRHISTSCALE * 32;
+constexpr S32 MAXCORRHISTUPDATE = MAXCORRHIST / 4;
+
 // Correction History
 extern S32 pawnsCorrHist[2][CORRHISTSIZE];
 extern S32 nonPawnsCorrHist[2][2][CORRHISTSIZE];


### PR DESCRIPTION
Really powerful tweak by @mcthouacbb . Seems to reduce strange corrhists score biases.

Elo   | 4.76 +- 3.62 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 14164 W: 4144 L: 3950 D: 6070
Penta | [248, 1689, 3069, 1773, 303]
https://perseusopenbench.pythonanywhere.com/test/377/

bench 3379758