### PR TITLE
Introduce FromTo threats indexing in capture history.

### DIFF
--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -625,7 +625,7 @@ bool Position::makeMove(Move move)
 inline void Position::addEp(MoveList* ml, ScoredMove move){
 
     const S32 score = pieceValues[P] * captScoreMvvMultiplier()
-                    + captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][P];
+                    + captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][P][getThreatsIndexing(threats, move)];
 
     ml->moves[ml->count++] = ((
         score
@@ -641,7 +641,7 @@ inline void Position::addPromoCapture(MoveList* ml, ScoredMove move, Piece moved
             + pieceValues[promotion]
             + pieceValues[capturedPiece]
             - pieceValues[P]
-            + captureHistoryTable[indexPieceTo(movedPiece, moveTarget(move))][capturedPiece - 6 * (capturedPiece >= 6)]; // Piece captured can't be NOPIECE (12), so this works
+            + captureHistoryTable[indexPieceTo(movedPiece, moveTarget(move))][capturedPiece - 6 * (capturedPiece >= 6)][getThreatsIndexing(threats, move)]; // Piece captured can't be NOPIECE (12), so this works
         
         ml->moves[ml->count++] = ((
             score
@@ -653,7 +653,7 @@ inline void Position::addPromoCapture(MoveList* ml, ScoredMove move, Piece moved
             + pieceValues[promotion]
             + pieceValues[capturedPiece]
             - pieceValues[P]
-            + captureHistoryTable[indexPieceTo(movedPiece, moveTarget(move))][capturedPiece - 6 * (capturedPiece >= 6)]; // Piece captured can't be NOPIECE (12), so this works
+            + captureHistoryTable[indexPieceTo(movedPiece, moveTarget(move))][capturedPiece - 6 * (capturedPiece >= 6)][getThreatsIndexing(threats, move)]; // Piece captured can't be NOPIECE (12), so this works
         
         ml->moves[ml->count++] = ((
             score
@@ -666,7 +666,7 @@ inline void Position::addPromoCapture(MoveList* ml, ScoredMove move, Piece moved
 inline void Position::addCapture(MoveList* ml, ScoredMove move, Piece movedPiece, Piece capturedPiece){
 
     const S32 score = pieceValues[capturedPiece] * captScoreMvvMultiplier()
-        + captureHistoryTable[indexPieceTo(movedPiece, moveTarget(move))][capturedPiece - 6 * (capturedPiece >= 6)]; // Piece captured can't be NOPIECE (12), so this works
+    + captureHistoryTable[indexPieceTo(movedPiece, moveTarget(move))][capturedPiece - 6 * (capturedPiece >= 6)][getThreatsIndexing(threats, move)]; // Piece captured can't be NOPIECE (12), so this works
 
     ml->moves[ml->count++] = ((
         score 
@@ -682,7 +682,7 @@ inline void Position::addPromotion(MoveList* ml, ScoredMove move){
         const S32 score = 
             + pieceValues[promotion]
             - pieceValues[P]
-            + captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][P];
+            + captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][P][getThreatsIndexing(threats, move)];
         ml->moves[ml->count++] = ((
             score 
             + BADNOISYMOVE
@@ -692,7 +692,7 @@ inline void Position::addPromotion(MoveList* ml, ScoredMove move){
         const S32 score = 
             + pieceValues[promotion]
             - pieceValues[P]
-            + captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][P];
+            + captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][P][getThreatsIndexing(threats, move)];
 
         ml->moves[ml->count++] = ((
             score 
@@ -717,7 +717,7 @@ inline void Position::addQuiet(MoveList *ml, ScoredMove move, Square source, Squ
         return;
     }
     ml->moves[ml->count++] = ((
-        (S64)(historyTable[side][getThreatsIndexing(threats,move)][indexFromTo(source, target)]) 
+        (S64)(historyTable[side][indexFromTo(source, target)][getThreatsIndexing(threats,move)])
         + (S64)(ply1contHist ? ply1contHist[indexPieceTo(movePiece(move), target)] : 0)
         + (S64)(ply2contHist ? ply2contHist[indexPieceTo(movePiece(move), target)] : 0)
         + QUIETSCORE

--- a/src/history.h
+++ b/src/history.h
@@ -8,10 +8,10 @@
 struct Position;
 
 // history table
-extern S32 historyTable[2][4][NUM_SQUARES * NUM_SQUARES];
+extern S32 historyTable[2][NUM_SQUARES * NUM_SQUARES][4];
 
 // capture history table
-extern S32 captureHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES / 2]; // The color of the captured piece is always the opposite of the color of the moving piece
+extern S32 captureHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES / 2][4]; // The color of the captured piece is always the opposite of the color of the moving piece
 
 // counter move table
 extern Move counterMoveTable[NUM_SQUARES * NUM_SQUARES];


### PR DESCRIPTION
One of the most curious thing to ever happen in Perseus.

Introduce FromTo threats capture history. Tests for indexing using only [from](https://perseusopenbench.pythonanywhere.com/test/414/) or [to](https://perseusopenbench.pythonanywhere.com/test/415/) were fails. To date, it is by far the longest test ever needed (game number wise).

Elo   | 1.66 +- 1.32 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 104202 W: 29713 L: 29215 D: 45274
Penta | [1940, 12359, 23141, 12585, 2076]
https://perseusopenbench.pythonanywhere.com/test/413/
bench 3483966