### PR TITLE
Add tt depth IIR condition and avoid double reductions on pvcutnodes

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -177,8 +177,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
     UndoInfo undoer = UndoInfo(pos);
 
     if (!excludedMove){
-        if (PVNode && depth >= IIRDepth() && !ttMove) --depth; 
-        if (cutNode && depth >= IIRDepth() && !ttMove) --depth; 
+        if ((PVNode || cutNode) && depth >= IIRDepth() && (!ttMove || ttDepth + 3 < depth)) --depth; 
     }
 
     if (inCheck)


### PR DESCRIPTION
Elo   | 7.85 +- 4.08 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10754 W: 3122 L: 2879 D: 4753
Penta | [181, 1209, 2378, 1404, 205]
https://perseusopenbench.pythonanywhere.com/test/419/
bench 2935014