### PR TITLE
Add PVS SEE pruning

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -176,6 +176,11 @@ TUNE_PARAM(lmrBadNoisyCutNode, 677, 250, 2750, 150, 0.002);
 TUNE_PARAM(lmrNoisyHistoryDivisorA, 5326, 2000, 16000, 700, 0.002)
 TUNE_PARAM(lmrNoisyHistoryDivisorB, 6861, 2000, 16000, 700, 0.002)
 
+// PVS SEE
+TUNE_PARAM(pvsSeeThresholdNoisy, -32, -160, -10, 8, 0.002)
+TUNE_PARAM(pvsSeeThresholdQuiet, -112, -160, -10, 8, 0.002)
+TUNE_PARAM(pvsSeeMaxDepth, 7, 5, 10, 0.5, 0.002)
+
 // LMP values
 TUNE_PARAM(lmpA0, 523, 500, 1500, 50, 0.002);
 TUNE_PARAM(lmpC0, 1620, 500, 5000, 225, 0.002);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -300,6 +300,7 @@ skipPruning:
         Move currMove = onlyMove(moveList.moves[i]);
         if (sameMovePos(currMove, excludedMove)) continue;
         const bool isQuiet = okToReduce(currMove);
+        const bool quietOrLosing = currMoveScore < COUNTERSCORE;
         if (moveSearched){
             if (!skipQuiets) { 
                 if (!PVNode && moveSearched >= lmpMargin[depth][improving]) skipQuiets = true;
@@ -319,7 +320,12 @@ skipPruning:
                     continue;
                 }
             }
-            else if (currMoveScore < COUNTERSCORE) continue;
+            else if (quietOrLosing) continue;
+            const auto seeThresh = isQuiet
+                ? pvsSeeThresholdNoisy() * depth 
+                : pvsSeeThresholdQuiet() * depth * depth
+            ;
+            if (quietOrLosing && depth <= pvsSeeMaxDepth() && !pos.SEE(currMove, seeThresh)) continue;
         }
         // assert (
         //     i != 0 || !excludedMove ||


### PR DESCRIPTION
Elo   | 14.87 +- 5.75 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 5212 W: 1585 L: 1362 D: 2265
Penta | [78, 513, 1237, 664, 114]
https://perseusopenbench.pythonanywhere.com/test/420/
bench 2378582