### PR TITLE
Add Post-LMR Continuation History Update

### DIFF
--- a/src/history.cpp
+++ b/src/history.cpp
@@ -22,27 +22,6 @@ S32 pawnsCorrHist[2][CORRHISTSIZE]; // stm - hash
 S32 nonPawnsCorrHist[2][2][CORRHISTSIZE]; // stm - side - hash
 S32 tripletCorrHist[10][2][CORRHISTSIZE]; // stm - hash
 
-static inline void updateHistoryMove(const bool side, const BitBoard threats, const Move move, const S32 delta) {
-    S32 *current = &historyTable[side][indexFromTo(moveSource(move), moveTarget(move))][getThreatsIndexing(threats, move)];
-    *current += delta - *current * abs(delta) / MAXHISTORYABS;
-}
-
-static inline void updateCaptureHistory(Move move, const BitBoard threats, S32 delta) {
-    Piece captured = moveCapture(move);
-    S32 *current = &captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][captured == NOPIECE ? P : captured % 6][getThreatsIndexing(threats, move)]; // account for promotion
-    *current += delta - *current * abs(delta) / MAXHISTORYABS;
-}
-
-static inline void updateContHistOffset(SStack* ss, const Move move, const S32 delta, const S32 offset){
-    S32 *current = &(ss - offset)->contHistEntry[indexPieceTo(movePiece(move), moveTarget(move))];
-    *current += delta - *current * abs(delta) / MAXHISTORYABS;
-}
-
-static inline void updateContHist(SStack* ss, const Move move, const S32 delta){
-    updateContHistOffset(ss, move, delta, 1);
-    updateContHistOffset(ss, move, delta, 2);
-}
-
 void updateHH(SStack* ss, bool side, BitBoard threats, Depth depth, Move bestMove, Move *quietMoves, U16 quietsCount, Move *noisyMoves, U16 noisyCount) {
     const S32 bonus = statBonus(depth);
     const S32 malus = statMalus(depth);

--- a/src/history.h
+++ b/src/history.h
@@ -84,3 +84,24 @@ void updateHH(SStack* ss, bool side, BitBoard threats, Depth depth, Move bestMov
 Score correctStaticEval(Position& pos, const Score eval);
 
 void updateCorrHist(Position& pos, const Score bonus, const Depth depth);
+
+static inline void updateHistoryMove(const bool side, const BitBoard threats, const Move move, const S32 delta) {
+    S32 *current = &historyTable[side][indexFromTo(moveSource(move), moveTarget(move))][getThreatsIndexing(threats, move)];
+    *current += delta - *current * abs(delta) / MAXHISTORYABS;
+}
+
+static inline void updateCaptureHistory(Move move, const BitBoard threats, S32 delta) {
+    Piece captured = moveCapture(move);
+    S32 *current = &captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][captured == NOPIECE ? P : captured % 6][getThreatsIndexing(threats, move)]; // account for promotion
+    *current += delta - *current * abs(delta) / MAXHISTORYABS;
+}
+
+static inline void updateContHistOffset(SStack* ss, const Move move, const S32 delta, const S32 offset){
+    S32 *current = &(ss - offset)->contHistEntry[indexPieceTo(movePiece(move), moveTarget(move))];
+    *current += delta - *current * abs(delta) / MAXHISTORYABS;
+}
+
+static inline void updateContHist(SStack* ss, const Move move, const S32 delta){
+    updateContHistOffset(ss, move, delta, 1);
+    updateContHistOffset(ss, move, delta, 2);
+}

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -433,6 +433,10 @@ skipPruning:
                     bool shallower = score < bestScore + 8;
                     newDepth += deeper - shallower; 
                     score = -search(-alpha - 1, -alpha, newDepth, !cutNode, ss + 1);
+                    if (isQuiet && (score <= alpha || score >= beta)){
+                        const auto bonus = score <= alpha ? -statMalus(newDepth) : statBonus(newDepth);
+                        updateContHist(ss, currMove, bonus);
+                    }
                 }
             }
             else 


### PR DESCRIPTION
Elo   | 8.31 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 9992 W: 2851 L: 2612 D: 4529
Penta | [142, 1170, 2199, 1277, 208]
https://perseusopenbench.pythonanywhere.com/test/427/
bench 2733583