### PR TITLE
Add simple material phase to the final eval based on SEE values

### DIFF
--- a/src/Game.cpp
+++ b/src/Game.cpp
@@ -262,7 +262,12 @@ bool Game::isRepetition() {
  * @return The static evaluation of the current position.
  */
 Score Game::evaluate(){
-    return pestoEval(&pos);
+    const auto matScaleValues = 
+        popcount(pos.bitboards[N] | pos.bitboards[B] | pos.bitboards[n] | pos.bitboards[b]) * pieceValues[N]
+        + popcount(pos.bitboards[R] | pos.bitboards[r]) * pieceValues[R]
+        + popcount(pos.bitboards[Q] | pos.bitboards[q]) * pieceValues[Q];
+
+    return pestoEval(&pos) * (27075 + matScaleValues) / 32768;
 }
 
 void Game::makeNullMove() {


### PR DESCRIPTION
Elo   | 3.37 +- 2.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 29724 W: 8284 L: 7996 D: 13444
Penta | [522, 3379, 6731, 3749, 481]
https://perseusopenbench.pythonanywhere.com/test/432/
bench 2594815