### PR TITLE
50 mr eval scaling

### DIFF
--- a/src/Position.h
+++ b/src/Position.h
@@ -2,7 +2,6 @@
 #include "move.h"
 #include <algorithm>
 #include "BBmacros.h"
-#include "history.h"
 #include "movegen.h"
 
 // We love forward decl
@@ -211,10 +210,10 @@ struct Position{
     inline void addUnsorted(MoveList *ml, ScoredMove move);
 
     /**
-	* @brief The getFEN function returns the FEN string of the current position
-	* @return The FEN string of the current position
+    * @brief The getFEN function returns the FEN string of the current position
+    * @return The FEN string of the current position
     */
-	std::string getFEN();
+    std::string getFEN();
     
     /**
      * @brief The SEE function evaluates a move using the Static Exchange Evaluation algorithm.
@@ -226,7 +225,7 @@ struct Position{
 
     bool inCheck();
 
-	bool insufficientMaterial();
+    bool insufficientMaterial();
 
     void reflect();
 };

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -45,33 +45,6 @@ void updateHH(SStack* ss, bool side, BitBoard threats, Depth depth, Move bestMov
     }
 }
 
-Score correctStaticEval(Position& pos, const Score eval) {
-    const bool side = pos.side;
-    auto const& k = pos.ptKeys;
-
-    const S32 bonus = 
-        + pawnsCorrHist[side][pos.pawnHashKey % CORRHISTSIZE]           * pawnCorrWeight()
-        + (
-            + nonPawnsCorrHist[side][WHITE][pos.nonPawnKeys[WHITE] % CORRHISTSIZE]
-            + nonPawnsCorrHist[side][BLACK][pos.nonPawnKeys[BLACK] % CORRHISTSIZE]
-        )                                                               * nonPawnCorrWeight()
-        + tripletCorrHist[0][side][(k[K] ^ k[P] ^ k[N]) % CORRHISTSIZE] * T0CorrWeight()
-        + tripletCorrHist[1][side][(k[K] ^ k[P] ^ k[B]) % CORRHISTSIZE] * T1CorrWeight()
-        + tripletCorrHist[2][side][(k[K] ^ k[P] ^ k[R]) % CORRHISTSIZE] * T2CorrWeight()
-        + tripletCorrHist[3][side][(k[K] ^ k[P] ^ k[Q]) % CORRHISTSIZE] * T3CorrWeight()
-        + tripletCorrHist[4][side][(k[K] ^ k[N] ^ k[B]) % CORRHISTSIZE] * T4CorrWeight()
-        + tripletCorrHist[5][side][(k[K] ^ k[N] ^ k[R]) % CORRHISTSIZE] * T5CorrWeight()
-        + tripletCorrHist[6][side][(k[K] ^ k[N] ^ k[Q]) % CORRHISTSIZE] * T6CorrWeight()
-        + tripletCorrHist[7][side][(k[K] ^ k[B] ^ k[R]) % CORRHISTSIZE] * T7CorrWeight()
-        + tripletCorrHist[8][side][(k[K] ^ k[B] ^ k[Q]) % CORRHISTSIZE] * T8CorrWeight()
-        + tripletCorrHist[9][side][(k[K] ^ k[R] ^ k[Q]) % CORRHISTSIZE] * T9CorrWeight()
-    ;
-
-    const S32 corrected = eval + bonus / (CORRHISTSCALE * CORRECTIONGRANULARITY);
-
-    return static_cast<Score>(std::clamp(corrected, -mateValue, +mateValue));
-}
-
 static inline void updateSingleCorrHist(S32& entry, const S32 bonus, const S32 weight){
     const S32 MAXCORRHIST = CORRHISTSCALE * MAXCORRHISTUNSCALED();
     const S32 MAXCORRHISTUPDATE = MAXCORRHIST * MAXCORRHISTMILLIUPDATE() / CORRECTIONGRANULARITY;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -193,7 +193,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
     {
         // Check if the eval is stored in the TT
         rawEval = tte->eval != noScore ? tte->eval : evaluate();
-        eval = ss->staticEval = ttMove ? rawEval : correctStaticEval(pos, rawEval);
+        eval = ss->staticEval = ttMove ? correctStaticEval<false>(pos, rawEval) : correctStaticEval<true>(pos, rawEval);
         // Also, we might be able to use the score as a better eval
         if (ttScore != noScore && (ttBound == hashEXACT || (ttBound == hashUPPER && ttScore < eval) || (ttBound == hashLOWER && ttScore > eval)))
             eval = ttScore;
@@ -206,7 +206,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
     }
     else {
         rawEval = evaluate();
-        eval = ss->staticEval = correctStaticEval(pos, rawEval);
+        eval = ss->staticEval = correctStaticEval<true>(pos, rawEval);
         // Store the eval in the TT if not in exclusion mode (in which we might already have the entry)
         writeTT(pos.hashKey, noScore, eval, 0, hashNONE, 0, ply, PVNode, ttPv);
     }
@@ -560,13 +560,13 @@ Score Game::quiescence(Score alpha, Score beta, SStack *ss)
     }
     else if (ttHit){
         rawEval = tte->eval != noScore ? tte->eval : evaluate();
-        ss->staticEval = bestScore = ttMove ? rawEval : correctStaticEval(pos, rawEval);
+        ss->staticEval = bestScore = ttMove ? correctStaticEval<false>(pos, rawEval) : correctStaticEval<true>(pos, rawEval);
         if (ttScore != noScore && (ttBound == hashEXACT || (ttBound == hashUPPER && ttScore < bestScore) || (ttBound == hashLOWER && ttScore > bestScore)))
             bestScore = ttScore;
     }
     else {
         rawEval = evaluate();
-        ss->staticEval = bestScore = correctStaticEval(pos, rawEval);
+        ss->staticEval = bestScore = correctStaticEval<true>(pos, rawEval);
         writeTT(pos.hashKey, noScore, bestScore, 0, hashNONE, 0, ply, PVNode, ttPv);
     }
 


### PR DESCRIPTION
Elo   | 2.69 +- 2.06 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 41016 W: 11207 L: 10890 D: 18919
Penta | [663, 4848, 9177, 5149, 671]
https://perseusopenbench.pythonanywhere.com/test/439/
bench 2618694