### PR TITLE
Move count based qsearch pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -585,8 +585,11 @@ Score Game::quiescence(Score alpha, Score beta, SStack *ss)
     for (int i = sortTTUp(moveList, ttMove); i < moveList.count; i++)
     {
         Move move = onlyMove(moveList.moves[i]);
+
+        // Move count pruning
+        if (!inCheck && moveCount >= 2) break;
         
-        // SEE pruning : skip all moves that have see < -100 (We may want to do this with a threshold of 0, but we would introduce another see call. TODO: lazily evaluate the see so that we can skip moves with see < 0)
+        // SEE pruning : skip all moves that have see < of the adaptive capthist based threshold
         if (!inCheck && moveCount && getScore(moveList.moves[i]) < GOODNOISYMOVE)
             break;
         if (makeMove(move))


### PR DESCRIPTION
Elo   | 2.17 +- 1.73 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 56566 W: 15369 L: 15015 D: 26182
Penta | [819, 6781, 12781, 7031, 871]
https://perseusopenbench.pythonanywhere.com/test/443/
bench 2503200