### PR TITLE
Use 16 bit arrays for histories

### DIFF
--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -703,7 +703,7 @@ inline void Position::addPromotion(MoveList* ml, ScoredMove move){
     return;
 }
 
-inline void Position::addQuiet(MoveList *ml, ScoredMove move, Square source, Square target, Move killer1, Move killer2, Move counterMove, const S32 *ply1contHist, const S32 *ply2contHist, const S32 *ply4contHist) {
+inline void Position::addQuiet(MoveList *ml, ScoredMove move, Square source, Square target, Move killer1, Move killer2, Move counterMove, const S16 *ply1contHist, const S16 *ply2contHist, const S16 *ply4contHist) {
     if (sameMovePos(move, killer1)){
         ml->moves[ml->count++] = (KILLER1SCORE << 32) | move;
         return;
@@ -918,9 +918,9 @@ void Position::generateMoves(MoveList& moveList, SStack* ss) {
     const Move killer2 = ss->killers[1];
     const Move lastMove = (ss-1)->move;
     const Move counterMove = lastMove ? counterMoveTable[indexFromTo(moveSource(lastMove), moveTarget(lastMove))] : noMove;
-    const S32 *ply1contHist = lastMove ? (ss - 1)->contHistEntry : nullptr;
-    const S32 *ply2contHist = (ss - 2)->move ? (ss - 2)->contHistEntry : nullptr;
-    const S32 *ply4contHist = (ss - 4)->move ? (ss - 4)->contHistEntry : nullptr;
+    const S16 *ply1contHist = lastMove ? (ss - 1)->contHistEntry : nullptr;
+    const S16 *ply2contHist = (ss - 2)->move ? (ss - 2)->contHistEntry : nullptr;
+    const S16 *ply4contHist = (ss - 4)->move ? (ss - 4)->contHistEntry : nullptr;
 
     BitBoard ourPawns   = bitboards[P + 6 * side];
     BitBoard ourKnights = bitboards[N + 6 * side];

--- a/src/Position.h
+++ b/src/Position.h
@@ -205,7 +205,7 @@ struct Position{
     template <Piece promotion>
     inline void addPromotion(MoveList *ml, ScoredMove move);
 
-    inline void addQuiet(MoveList *ml, ScoredMove move, Square source, Square target, Move killer1, Move killer2, Move counterMove, const S32 *ply1contHist, const S32 *ply2contHist, const S32 *ply4contHist);
+    inline void addQuiet(MoveList *ml, ScoredMove move, Square source, Square target, Move killer1, Move killer2, Move counterMove, const S16 *ply1contHist, const S16 *ply2contHist, const S16 *ply4contHist);
 
     inline void addUnsorted(MoveList *ml, ScoredMove move);
 

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -6,16 +6,16 @@
 #include <algorithm>
 
 // history table
-S32 historyTable[2][NUM_SQUARES * NUM_SQUARES][4];
+S16 historyTable[2][NUM_SQUARES * NUM_SQUARES][4];
 
 // capture history table
-S32 captureHistoryTable[NUM_PIECES * NUM_SQUARES][6][4];
+S16 captureHistoryTable[NUM_PIECES * NUM_SQUARES][6][4];
 
 // counter move table
 Move counterMoveTable[NUM_SQUARES * NUM_SQUARES];
 
 // Continuation History table
-S32 continuationHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES * NUM_SQUARES];
+S16 continuationHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES * NUM_SQUARES];
 
 // Correction History
 S32 pawnsCorrHist[2][CORRHISTSIZE]; // stm - hash

--- a/src/history.h
+++ b/src/history.h
@@ -5,16 +5,16 @@
 #include "Position.h"
 
 // history table
-extern S32 historyTable[2][NUM_SQUARES * NUM_SQUARES][4];
+extern S16 historyTable[2][NUM_SQUARES * NUM_SQUARES][4];
 
 // capture history table
-extern S32 captureHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES / 2][4]; // The color of the captured piece is always the opposite of the color of the moving piece
+extern S16 captureHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES / 2][4]; // The color of the captured piece is always the opposite of the color of the moving piece
 
 // counter move table
 extern Move counterMoveTable[NUM_SQUARES * NUM_SQUARES];
 
 // Continuation History table
-extern S32 continuationHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES * NUM_SQUARES];
+extern S16 continuationHistoryTable[NUM_PIECES * NUM_SQUARES][NUM_PIECES * NUM_SQUARES];
 
 constexpr S32 CORRHISTSIZE = 16384;
 constexpr S32 CORRHISTSCALE = 256;
@@ -32,7 +32,7 @@ struct SStack {
     Move move = 0;
     S16 doubleExtensions = 0;
     Move killers[2] = {0, 0};
-    S32* contHistEntry = continuationHistoryTable[0];
+    S16* contHistEntry = continuationHistoryTable[0];
 
     SStack() {
         excludedMove = noMove;
@@ -119,18 +119,18 @@ Score correctStaticEval(Position& pos, const Score eval) {
 void updateCorrHist(Position& pos, const Score bonus, const Depth depth);
 
 static inline void updateHistoryMove(const bool side, const BitBoard threats, const Move move, const S32 delta) {
-    S32 *current = &historyTable[side][indexFromTo(moveSource(move), moveTarget(move))][getThreatsIndexing(threats, move)];
+    S16 *current = &historyTable[side][indexFromTo(moveSource(move), moveTarget(move))][getThreatsIndexing(threats, move)];
     *current += delta - *current * abs(delta) / MAXHISTORYABS;
 }
 
 static inline void updateCaptureHistory(Move move, const BitBoard threats, S32 delta) {
     Piece captured = moveCapture(move);
-    S32 *current = &captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][captured == NOPIECE ? P : captured % 6][getThreatsIndexing(threats, move)]; // account for promotion
+    S16 *current = &captureHistoryTable[indexPieceTo(movePiece(move), moveTarget(move))][captured == NOPIECE ? P : captured % 6][getThreatsIndexing(threats, move)]; // account for promotion
     *current += delta - *current * abs(delta) / MAXHISTORYABS;
 }
 
 static inline void updateContHistOffset(SStack* ss, const Move move, const S32 delta, const S32 offset){
-    S32 *current = &(ss - offset)->contHistEntry[indexPieceTo(movePiece(move), moveTarget(move))];
+    S16 *current = &(ss - offset)->contHistEntry[indexPieceTo(movePiece(move), moveTarget(move))];
     *current += delta - *current * abs(delta) / MAXHISTORYABS;
 }
 


### PR DESCRIPTION
Elo   | 3.06 +- 2.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 16694 W: 4613 L: 4466 D: 7615
Penta | [160, 1686, 4535, 1779, 187]
https://perseusopenbench.pythonanywhere.com/test/458/
bench 2460917