### PR TITLE
Obsidian style qsearch incheck pruning

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -611,6 +611,10 @@ Score Game::quiescence(Score alpha, Score beta, SStack *ss)
                         break;
                     alpha = score;
                 }
+                // Obsidian ml pruning idea
+                if (bestScore >= -KNOWNWIN) {
+                    if (pos.checkers && okToReduce(move)) break;
+                }
             }
         }
         else


### PR DESCRIPTION
Very nice idea from [Obsidian](https://github.com/gab8192/Obsidian).
Elo   | 5.10 +- 3.12 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 16684 W: 4496 L: 4251 D: 7937
Penta | [195, 1975, 3810, 2114, 248]
https://perseusopenbench.pythonanywhere.com/test/473/
bench 2466815