### PR TITLE
Add SEE based futility pruning in quiescence search

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -219,6 +219,7 @@ NO_TUNE_PARAM(IIRDepth, 5, 3, 8, .5, 0.002);
 TUNE_PARAM(futPruningMultiplier, 54, 30, 130, 5, 0.002);
 TUNE_PARAM(futPruningAdd, 241, 150, 350, 10, 0.002);
 NO_TUNE_PARAM(futPruningDepth, 9, 6, 10, 0.5, 0.002);
+TUNE_PARAM(qsFutilityMargin, 68, 0, 250, 13, 0.002)
 
 // Move ordering values
 TUNE_PARAM(captScoreMvvMultiplier, 14, 8, 32, 1, 0.002)


### PR DESCRIPTION
Elo   | 2.22 +- 1.76 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 52566 W: 14076 L: 13740 D: 24750
Penta | [673, 6287, 12079, 6519, 725]
https://perseusopenbench.pythonanywhere.com/test/485/
bench 2409759