### PR TITLE
Nmp static eval margin conditions

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -192,8 +192,8 @@ TUNE_PARAM(futilityMarginDelta, 99, 55, 155, 5, 0.002);
 NO_TUNE_PARAM(RFPDepth, 8, 5, 10, .5, 0.002);
 
 // NMP values
-TUNE_PARAM(nmpMarginBias, 90, 100, 300, 10, 0.002);
-TUNE_PARAM(nmpDepthMargin, 15, 10, 50, 2, 0.002);
+TUNE_PARAM(nmpMarginBias, 175, 100, 300, 10, 0.002);
+TUNE_PARAM(nmpDepthMargin, 25, 10, 50, 2, 0.002);
 NO_TUNE_PARAM(nmpDepthDivisor, 4, 2, 6, .5, 0.002);
 TUNE_PARAM(nmpScoreDivisor, 216, 100, 300, 10, 0.002);
 NO_TUNE_PARAM(nmpQ1, 3, 1, 5, .5, 0.002);

--- a/src/constants.h
+++ b/src/constants.h
@@ -192,8 +192,8 @@ TUNE_PARAM(futilityMarginDelta, 99, 55, 155, 5, 0.002);
 NO_TUNE_PARAM(RFPDepth, 8, 5, 10, .5, 0.002);
 
 // NMP values
-TUNE_PARAM(nmpMarginBias, 175, 100, 300, 10, 0.002);
-TUNE_PARAM(nmpDepthMargin, 25, 10, 50, 2, 0.002);
+TUNE_PARAM(nmpMarginBias, 90, 100, 300, 10, 0.002);
+TUNE_PARAM(nmpDepthMargin, 15, 10, 50, 2, 0.002);
 NO_TUNE_PARAM(nmpDepthDivisor, 4, 2, 6, .5, 0.002);
 TUNE_PARAM(nmpScoreDivisor, 216, 100, 300, 10, 0.002);
 NO_TUNE_PARAM(nmpQ1, 3, 1, 5, .5, 0.002);

--- a/src/constants.h
+++ b/src/constants.h
@@ -192,6 +192,8 @@ TUNE_PARAM(futilityMarginDelta, 99, 55, 155, 5, 0.002);
 NO_TUNE_PARAM(RFPDepth, 8, 5, 10, .5, 0.002);
 
 // NMP values
+TUNE_PARAM(nmpMarginBias, 175, 100, 300, 10, 0.002);
+TUNE_PARAM(nmpDepthMargin, 25, 10, 50, 2, 0.002);
 NO_TUNE_PARAM(nmpDepthDivisor, 4, 2, 6, .5, 0.002);
 TUNE_PARAM(nmpScoreDivisor, 216, 100, 300, 10, 0.002);
 NO_TUNE_PARAM(nmpQ1, 3, 1, 5, .5, 0.002);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -289,11 +289,11 @@ skipPruning:
     // Iterate through moves
     for (int i = (ttMove ? sortTTUp(moveList, ttMove) : 1); i < moveList.count; i++) // Slot 0 is reserved for the tt move, wheter it is present or not
     {
-        S32 currMoveScore = getScore(moveList.moves[i]); // - BAD_NOISY_MOVE;
+        S32 currMoveScore = getScore(moveList.moves[i]); // - BADNOISYMOVE;
         Move currMove = onlyMove(moveList.moves[i]);
         if (sameMovePos(currMove, excludedMove)) continue;
         const bool isQuiet = okToReduce(currMove);
-        const bool quietOrLosing = currMoveScore < COUNTER_SCORE;
+        const bool quietOrLosing = currMoveScore < COUNTERSCORE;
         if (moveSearched){
             if (!skipQuiets) { 
                 if (!PVNode && moveSearched >= lmpMargin[depth][improving]) skipQuiets = true;
@@ -308,7 +308,7 @@ skipPruning:
                     skipQuiets = true;
                     continue;
                 }
-                if (!PVNode && depth <= 4 && (isQuiet ? (currMoveScore - QUIET_SCORE) : (currMoveScore - BAD_NOISY_MOVE)) < ( historyPruningMultiplier() * depth) + historyPruningBias()){
+                if (!PVNode && depth <= 4 && (isQuiet ? (currMoveScore - QUIETSCORE) : (currMoveScore - BADNOISYMOVE)) < ( historyPruningMultiplier() * depth) + historyPruningBias()){
                     skipQuiets = true;
                     continue;
                 }
@@ -399,19 +399,19 @@ skipPruning:
             if (moveSearched > PVNode * 3 && depth >= 3 && (isQuiet || !ttPv))
             {
                 S32 granularR = reduction(depth, moveSearched, isQuiet, ttPv);
-                if (currMoveScore >= COUNTER_SCORE) granularR -= lmrExpectedDecent();
+                if (currMoveScore >= COUNTERSCORE) granularR -= lmrExpectedDecent();
                 if (isQuiet){
                     // R -= givesCheck;
-                    granularR -= std::clamp((currMoveScore - QUIET_SCORE) * RESOLUTION, -16000000LL, 16000000LL) / lmrQuietHistoryDivisor();
+                    granularR -= std::clamp((currMoveScore - QUIETSCORE) * RESOLUTION, -16000000LL, 16000000LL) / lmrQuietHistoryDivisor();
                     if (cutNode) granularR += lmrQuietCutNode();
                     if (ttPv) granularR -= cutNode * lmrQuietTTPV();
                 }
                 else {
-                    if (currMoveScore < QUIET_SCORE) { 
+                    if (currMoveScore < QUIETSCORE) { 
                     if (cutNode) granularR += lmrBadNoisyCutNode();
-                        granularR -= std::clamp((currMoveScore - BAD_NOISY_MOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorA();
+                        granularR -= std::clamp((currMoveScore - BADNOISYMOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorA();
                     }
-                    granularR -= std::clamp((currMoveScore - GOOD_NOISY_MOVE - BAD_NOISY_MOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorB();
+                    granularR -= std::clamp((currMoveScore - GOODNOISYMOVE - BADNOISYMOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorB();
                 }
                 // The function looked cool on desmos
                 granularR -= lmrCieckA() * improvement / (std::abs(improvement * lmrCieckB() / 1000) + lmrCieckC());
@@ -585,7 +585,7 @@ Score Game::quiescence(Score alpha, Score beta, SStack *ss)
         if (!inCheck && moveCount >= 2) break;
         
         // SEE pruning : skip all moves that have see < of the adaptive capthist based threshold
-        if (!inCheck && moveCount && getScore(moveList.moves[i]) < GOOD_NOISY_MOVE)
+        if (!inCheck && moveCount && getScore(moveList.moves[i]) < GOODNOISYMOVE)
             break;
 
         // Futility pruning

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -232,12 +232,11 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
         }
 
         // Null move pruning
-        if (eval >= ss->staticEval &&
-            eval >= beta &&
-            (ss - 1)->move &&
+        if (ply >= nmpPlies &&
             depth >= 3 &&
-            okToReduce((ss - 1)->move) && pos.hasNonPawns() &&
-            ply >= nmpPlies)
+            eval >= beta &&
+            ss->staticEval >= beta + nmpMarginBias() + depth * nmpDepthMargin() &&
+            pos.hasNonPawns())
         {
 
             // make null move


### PR DESCRIPTION
Elo   | 6.55 +- 3.60 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12736 W: 3465 L: 3225 D: 6046
Penta | [165, 1457, 2913, 1639, 194]
https://perseusopenbench.pythonanywhere.com/test/492/
bench 2845904