### PR TITLE
more negext for non pvnodes

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -209,6 +209,7 @@ TUNE_PARAM(singularDepthMultiplier, 10, 1, 30, 2, 0.002);
 TUNE_PARAM(maximumDoubleExtensions, 7, 1, 9, 1, 0.002);
 TUNE_PARAM(doubleExtensionMargin, 23, 1, 50, 2.5, 0.002);
 NO_TUNE_PARAM(singularSearchDepth, 7, 5, 10, .5, 0.002);
+TUNE_PARAM(doubleNegExtMargin, 25, 1, 100, 5, 0.002);
 
 // History Pruning values
 TUNE_PARAM(historyPruningMultiplier, -1341, -5120, -1024, 205, 0.002);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -368,7 +368,10 @@ skipPruning:
                         undo(undoer, currMove);
                         return singularBeta;
                     }
-                    else if (ttScore >= beta || cutNode){
+                    else if (ttScore >= beta){
+                        extension -= 1 + !PVNode;
+                    }
+                    else if (cutNode){
                         extension = -1;
                     }
                     


### PR DESCRIPTION
Elo   | 1.45 +- 1.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 127502 W: 33969 L: 33438 D: 60095
Penta | [1729, 15199, 29456, 15546, 1821]
https://perseusopenbench.pythonanywhere.com/test/495/
bench 2734344