### PR TITLE
IIR more in pv nodes and less in non pv nodes

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -216,7 +216,7 @@ TUNE_PARAM(historyPruningMultiplier, -1341, -5120, -1024, 205, 0.002);
 TUNE_PARAM(historyPruningBias, -94, -2048, 2048, 205, 0.002);
 
 // IIR values
-NO_TUNE_PARAM(IIRDepth, 5, 3, 8, .5, 0.002);
+NO_TUNE_PARAM(IIRDepth, 6, 3, 8, .5, 0.002);
 
 // FFP values
 TUNE_PARAM(futPruningMultiplier, 54, 30, 130, 5, 0.002);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -171,7 +171,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
     UndoInfo undoer = UndoInfo(pos);
 
     if (!excludedMove){
-        if ((PVNode || cutNode) && depth >= IIRDepth() && (!ttMove || ttDepth + 3 < depth)) --depth; 
+        if ((PVNode || cutNode) && depth >= IIRDepth() - 2*PVNode && (!ttMove || ttDepth + 3 < depth)) --depth; 
     }
 
     if (inCheck)
@@ -268,7 +268,6 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
                     return nullScore;
             }
         }
-    
     }
 
 skipPruning:


### PR DESCRIPTION
Elo   | 1.85 +- 1.49 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 72672 W: 19200 L: 18814 D: 34658
Penta | [935, 8646, 16820, 8968, 967]
https://pyronomy.pythonanywhere.com/test/2042/
bench 2884595