### PR TITLE
Reduce more in Null Move Pruning when improving

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -244,7 +244,7 @@ Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *s
             ss->move = noMove;
             ss->contHistEntry = continuationHistoryTable[0];
 
-            Depth R = nmpQ1() + (depth / nmpDepthDivisor()) + std::min((eval - beta) / nmpScoreDivisor(), nmpQ2());
+            Depth R = nmpQ1() + (depth / nmpDepthDivisor()) + std::min((eval - beta) / nmpScoreDivisor(), nmpQ2()) + improving;
             Score nullScore = -search(-beta, -beta + 1, depth - R, !cutNode, ss + 1);
 
             undoNullMove(undoer);


### PR DESCRIPTION
Elo   | 2.56 +- 1.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 40948 W: 10688 L: 10386 D: 19874
Penta | [460, 4892, 9527, 5076, 519]
https://pyronomy.pythonanywhere.com/test/2128/
bench 2813920