### PR TITLE
Adjust reduction based on previous LMR reduction.

### DIFF
--- a/src/Game.h
+++ b/src/Game.h
@@ -125,7 +125,7 @@ public:
      * @param ss The SStack object to store the search information in
      * @return The score of the position
      */
-    Score search(Score alpha, Score beta, Depth depth, bool cutnode, SStack* ss);
+    Score search(Score alpha, Score beta, Depth depth, bool cutnode, SStack* ss, S32 prevRed = 0);
 
     /**
      * @brief The makeNullMove function makes a null move on the board.

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -69,7 +69,7 @@ static inline void clearKillers(SStack *ss)
     ss->killers[1] = noMove;
 }
 
-Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *ss)
+Score Game::search(Score alpha, Score beta, Depth depth, bool cutNode, SStack *ss, S32 prevRed)
 {
     // Comms
     if (nodes >= hardNodesLimit)
@@ -408,6 +408,7 @@ skipPruning:
                         granularR -= std::clamp((currMoveScore - GOODNOISYMOVE - BADNOISYMOVE) * RESOLUTION, -6000000LL, 12000000LL) / lmrNoisyHistoryDivisorB();
                     }
                 }
+                if (moveSearched >= 3) granularR -= prevRed * 512;
                 // The function looked cool on desmos
                 granularR -= lmrCieckA() * improvement / (std::abs(improvement * lmrCieckB() / 1000) + lmrCieckC());
                 Depth R = granularR / RESOLUTION;
@@ -415,7 +416,7 @@ skipPruning:
                 R = std::min(Depth(newDepth - Depth(1)), R);
                 Depth reducedDepth = newDepth - R;
                 // Search at reduced depth
-                score = -search(-alpha - 1, -alpha, reducedDepth, true, ss + 1);
+                score = -search(-alpha - 1, -alpha, reducedDepth, true, ss + 1, R);
                 // If failed high on reduced search, research at full depth
                 if (score > alpha && R){
                     bool deeper = score > bestScore + doDeeperMargin() + 2 * newDepth;


### PR DESCRIPTION
We use the previous LMR reduction to determine how confident we are in the move being a success.
For a move with high LMR reduction in the parent node, we expect a fast fail high in the current node (given that the previous move is assumed to be suboptimal).
Note that as we are in a non PV node, exact scores cannot happen.
If sufficient moves have passed without a fail high, it provides an indicator that the initial prediction could be incorrect. We dial down the confidence in the initial reduction by adjusting the child LMR searches accordingly.

Future extensions:
1. Consider the reduction we used in NMP or other heuristics as well
2. Use this in other heuristics
3. Make the coefficient adaptive to moves searched
4. Extend the whole node rather than just reducing LMR reduction (although this makes less sense to me, because we only actually search at full depth if an LMR search beats alpha (and consequently thus being >= beta, by extension of being in a non-PV node). This restores confidence in our initial prediction, so why should we also search the full depth search at an increased depth as well?)

Note to Gioviok: I did not compile or bench this patch