### PR TITLE
Consistent cached pawn eval block for passed pawns

### DIFF
--- a/src/evaluation.cpp
+++ b/src/evaluation.cpp
@@ -400,8 +400,7 @@ PawnStructureResult pawnStructureEval(
 
     // Compute "block" used for passed pawn bonus.
     // (For the side being evaluated, the block mask combines the overall occupancy with the enemy pawns’ defensive gaps.)
-    BitBoard block = occ[BOTH] | (~attackedBy[us] & attackedBy[them]) | 
-                     (~defendedByPawn[us] & ~multiAttacks[us] & (multiAttacks[them]));
+    BitBoard block = occ[BOTH] | (~defendedByPawn[us] & ((~attackedBy[us] & attackedBy[them]) | (multiAttacks[them])));
     PScore score = S(0,0);
     PScore extraScore = S(0,0);
     while (pieces) {
@@ -559,8 +558,7 @@ void extractPawnStructureFeats(
 
     // Compute "block" used for passed pawn bonus.
     // (For the side being evaluated, the block mask combines the overall occupancy with the enemy pawns’ defensive gaps.)
-    BitBoard block = occ[BOTH] | (~attackedBy[us] & attackedBy[them]) | 
-                     (~defendedByPawn[us] & ~multiAttacks[us] & (multiAttacks[them]));
+    BitBoard block = occ[BOTH] | (~defendedByPawn[us] & ((~attackedBy[us] & attackedBy[them]) | (multiAttacks[them])));
     while (pieces) {
         Square sq = popLsb(pieces);
         BitBoard sqb = squareBB(sq);


### PR DESCRIPTION
Its cursed that previous passed. Anywasy this clearly scales.

Elo   | 0.22 +- 1.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 63256 W: 16707 L: 16667 D: 29882
Penta | [790, 7609, 14767, 7695, 767]
https://perseusopenbench.pythonanywhere.com/test/501/

bench 2546128