### PR TITLE
Gigabrainconthistupdate

### DIFF
--- a/src/Position.cpp
+++ b/src/Position.cpp
@@ -737,9 +737,7 @@ inline void Position::addQuiet(MoveList *ml, ScoredMove move, Square source, Squ
     }
     ml->moves[ml->count++] = ((
         (S64)(historyTable[side][indexFromTo(source, target)][getThreatsIndexing(threats,move)])
-        + (S64)(ply1contHist ? ply1contHist[indexPieceTo(movePiece(move), target)] : 0)
-        + (S64)(ply2contHist ? ply2contHist[indexPieceTo(movePiece(move), target)] : 0)
-        + (S64)(ply4contHist ? ply4contHist[indexPieceTo(movePiece(move), target)] : 0)
+        + getContHistScore(ply1contHist, ply2contHist, ply4contHist, move)
         + QUIETSCORE
     ) << 32) | move;
 }

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -45,6 +45,15 @@ void updateHH(SStack* ss, bool side, BitBoard threats, Depth depth, Move bestMov
     }
 }
 
+S16 getContHistScore(const S16* ply1contHist, const S16* ply2contHist, const S16* ply4contHist, Move move) {
+    S32 score = 0;
+    size_t index = indexPieceTo(movePiece(move), moveTarget(move));
+    if (ply1contHist) score += ply1contHist[index];
+    if (ply2contHist) score += ply2contHist[index];
+    if (ply4contHist) score += ply4contHist[index];
+    return score;
+}
+
 static inline void updateSingleCorrHist(S32& entry, const S32 bonus, const S32 weight){
     const S32 MAXCORRHIST = CORRHISTSCALE * MAXCORRHISTUNSCALED();
     const S32 MAXCORRHISTUPDATE = MAXCORRHIST * MAXCORRHISTMILLIUPDATE() / CORRECTIONGRANULARITY;

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -45,7 +45,7 @@ void updateHH(SStack* ss, bool side, BitBoard threats, Depth depth, Move bestMov
     }
 }
 
-S16 getContHistScore(const S16* ply1contHist, const S16* ply2contHist, const S16* ply4contHist, Move move) {
+S32 getContHistScore(const S16* ply1contHist, const S16* ply2contHist, const S16* ply4contHist, Move move) {
     S32 score = 0;
     size_t index = indexPieceTo(movePiece(move), moveTarget(move));
     if (ply1contHist) score += ply1contHist[index];

--- a/src/history.h
+++ b/src/history.h
@@ -116,7 +116,7 @@ Score correctStaticEval(Position& pos, Score eval) {
 }
 
 void updateCorrHist(Position& pos, const Score bonus, const Depth depth);
-S16 getContHistScore(const S16* ply1contHist, const S16* ply2contHist, const S16* ply4contHist, Move move);
+S32 getContHistScore(const S16* ply1contHist, const S16* ply2contHist, const S16* ply4contHist, Move move);
 
 static inline void updateHistoryMove(const bool side, const BitBoard threats, const Move move, const S32 delta) {
     S16 *current = &historyTable[side][indexFromTo(moveSource(move), moveTarget(move))][getThreatsIndexing(threats, move)];

--- a/src/history.h
+++ b/src/history.h
@@ -116,6 +116,7 @@ Score correctStaticEval(Position& pos, Score eval) {
 }
 
 void updateCorrHist(Position& pos, const Score bonus, const Depth depth);
+S16 getContHistScore(const S16* ply1contHist, const S16* ply2contHist, const S16* ply4contHist, Move move);
 
 static inline void updateHistoryMove(const bool side, const BitBoard threats, const Move move, const S32 delta) {
     S16 *current = &historyTable[side][indexFromTo(moveSource(move), moveTarget(move))][getThreatsIndexing(threats, move)];
@@ -128,13 +129,25 @@ static inline void updateCaptureHistory(Move move, const BitBoard threats, S32 d
     *current += delta - *current * abs(delta) / MAXHISTORYABS;
 }
 
-static inline void updateContHistOffset(SStack* ss, const Move move, const S32 delta, const S32 offset){
-    S16 *current = &(ss - offset)->contHistEntry[indexPieceTo(movePiece(move), moveTarget(move))];
-    *current += delta - *current * abs(delta) / MAXHISTORYABS;
+static inline void updateSingleContHist(SStack* ss, const Move move, S32 base, S32 delta){
+    S16 *current = &ss->contHistEntry[indexPieceTo(movePiece(move), moveTarget(move))];
+    base = (3 * (*current) + base) / 4; 
+    S16 newValue = *current + delta - base * abs(delta) / MAXHISTORYABS;
+    *current = std::clamp(newValue, static_cast<S16>(-MAXHISTORYABS), static_cast<S16>(MAXHISTORYABS));
 }
 
 static inline void updateContHist(SStack* ss, const Move move, const S32 delta){
-    updateContHistOffset(ss, move, delta, 1);
-    updateContHistOffset(ss, move, delta, 2);
-    updateContHistOffset(ss, move, delta, 4);
+    S32 conthist = getContHistScore((ss-1)->move ? (ss - 1)->contHistEntry : nullptr,
+                                   (ss-2)->move ? (ss - 2)->contHistEntry : nullptr,
+                                   (ss-4)->move ? (ss - 4)->contHistEntry : nullptr,
+                                   move);
+    if ((ss-1)->move) {
+        updateSingleContHist(ss - 1, move, conthist, delta);
+    }
+    if ((ss-2)->move) {
+        updateSingleContHist(ss - 2, move, conthist, delta);
+    }
+    if ((ss-4)->move) {
+        updateSingleContHist(ss - 4, move, conthist, delta);
+    }
 }


### PR DESCRIPTION
Idea by Yoshie. Tested first in PlentyChess, adopted successfully by other engines.

Elo   | 4.63 +- 2.92 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18382 W: 4963 L: 4718 D: 8701
Penta | [196, 2171, 4242, 2356, 226]
https://perseusopenbench.pythonanywhere.com/test/565/

Bench: 2605137